### PR TITLE
add bottom-up heapsort

### DIFF
--- a/Makefile-ccan
+++ b/Makefile-ccan
@@ -38,6 +38,7 @@ MODS_WITH_SRC := antithread \
 	base64 \
 	bdelta \
 	block_pool \
+	bottom_up_heapsort \
 	breakpoint \
 	btree \
 	bytestring \

--- a/ccan/bottom_up_heapsort/LICENSE
+++ b/ccan/bottom_up_heapsort/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/BSD-3CLAUSE

--- a/ccan/bottom_up_heapsort/_info
+++ b/ccan/bottom_up_heapsort/_info
@@ -1,0 +1,67 @@
+#include <string.h>
+#include "config.h"
+
+/**
+ * bottom_up_heapsort - bottom-up version of heapsort
+ *
+ * modified version of bottom up heapsort,
+ * see details here: http://blog.dataparksearch.org/397
+ * It is also unified with asort() to be typesafe and
+ * takes a context pointer for comparison function.
+ *
+ * License: BSD (3 clause)
+ * Author: Maxim Zakharov <dp.maxime@gmail.com>
+ *
+ * Example:
+ *	#include <ccan/bottom_up_heapsort/bottom_up_heapsort.h>
+ *	#include <stdio.h>
+ *	#include <string.h>
+ *	
+ *	static int cmp(char *const *a, char *const *n, bool *casefold)
+ *	{
+ *		if (*casefold)
+ *			return strcasecmp(*a, *n);
+ *		else
+ *			return strcmp(*a, *n);
+ *	}
+ *	
+ *	int main(int argc, char *argv[])
+ *	{
+ *		bool casefold = false;
+ *		unsigned int i;
+ *	
+ *		if (argc < 2) {
+ *			fprintf(stderr, "Usage: %s [-i] <list>...\n"
+ *				"Sort arguments (-i = ignore case)\n",
+ *				argv[0]);
+ *			exit(1);
+ *		}
+ *	
+ *		if (strcmp(argv[1], "-i") == 0) {
+ *			casefold = true;
+ *			argc--;
+ *			argv++;
+ *		}
+ *		bottom_up_heapsort(&argv[1], argc-1, cmp, &casefold);
+ *		for (i = 1; i < argc; i++)
+ *			printf("%s ", argv[i]);
+ *		printf("\n");
+ *		return 0;
+ *	}
+ */
+int main(int argc, char *argv[])
+{
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		printf("ccan/order\n");
+		return 0;
+	}
+	if (strcmp(argv[1], "testdepends") == 0) {
+		printf("ccan/array_size\n");
+		return 0;
+	}
+
+	return 1;
+}

--- a/ccan/bottom_up_heapsort/bottom_up_heapsort.c
+++ b/ccan/bottom_up_heapsort/bottom_up_heapsort.c
@@ -1,0 +1,170 @@
+/* 3-clause BSD license - see LICENSE file for details */
+#include <ccan/bottom_up_heapsort/bottom_up_heapsort.h>
+/*
+  Copyright (c) 2013,2015, Maxim Zakharov
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice, this
+    list of conditions and the following disclaimer in the documentation and/or
+    other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+/*
+ * Swap two areas of size number of bytes.  Although qsort(3) permits random
+ * blocks of memory to be sorted, sorting pointers is almost certainly the
+ * common case (and, were it not, could easily be made so).  Regardless, it
+ * isn't worth optimizing; the SWAP's get sped up by the cache, and pointer
+ * arithmetic gets lost in the time required for comparison function calls.
+ */
+#define	SWAP(a, b, count, size, tmp) { \
+	count = size; \
+	do { \
+		tmp = *a; \
+		*a++ = *b; \
+		*b++ = tmp; \
+	} while (--count); \
+}
+
+/* Copy one block of size size to another. */
+#define COPY(a, b, count, size, tmp1, tmp2) { \
+	count = size; \
+	tmp1 = a; \
+	tmp2 = b; \
+	do { \
+		*tmp1++ = *tmp2++; \
+	} while (--count); \
+}
+
+/*
+   Modified version of BOTTOM-UP-HEAPSORT
+   Ingo Wegener, BOTTOM-UP-HEAPSORT, a new variant of HEAPSORT beating,
+   on an average, QUICKSORT (if n is not very small), Theoretical Computer Science 118 (1993),
+   pp. 81-98, Elsevier; n >= 16000 for median-3 version of QUICKSORT
+
+   The idea of delayed reheap after moving the root to its place is from
+   D. Levendeas, C. Zaroliagis, Heapsort using Multiple Heaps, in Proc. 2nd Panhellenic
+   Student Conference on Informatics -- EUREKA. – 2008. – P. 93–104.
+   It saves (n-2)/2 swaps and (n-2)/2 comparisons, for n > 3.
+*/
+
+/* Search for the special leaf. */
+#define LEAF_SEARCH(m, i, j) { \
+	j = i; \
+	while ((j << 1) < m) {	\
+	    j <<= 1; \
+	    if ((*compar)(base + j * size, base + size * (j + 1), arg) < 0) j++; \
+	} \
+	if ((j << 1) == m) j = m; \
+    }
+
+/* Find the place of a[i] in the path to the special leaf. */
+#define BOTTOM_UP_SEARCH(i, j) {					\
+	while(j > i && (*compar)(base + i * size, base + j * size, arg) > 0) { \
+	    j >>= 1; \
+	} \
+    }
+
+/* Rearrange the elements in the path. */
+#define INTERCHANGE(i, j) { \
+	COPY(k, base + j * size, cnt, size, tmp1, tmp2); \
+	COPY(base + j * size, base + i * size, cnt, size, tmp1, tmp2); \
+	while (i < j) { \
+	    j >>= 1; \
+	    p = base + j * size; \
+	    t = k; \
+	    SWAP(t, p, cnt, size, tmp);	\
+	} \
+    }
+
+/* Bottom-up reheap procedure. */
+#define BOTTOM_UP_REHEAP(m, i) { \
+	LEAF_SEARCH(m, i, j); \
+	BOTTOM_UP_SEARCH(i, j); \
+	INTERCHANGE(i, j); \
+    }
+
+int
+_bottom_up_heapsort(void *vbase, size_t nmemb, size_t size,
+		    int (*compar)(const void *, const void *, void*), void *arg)
+{
+    size_t cnt, i, j;
+    ssize_t l;
+    char tmp, *tmp1, *tmp2;
+    char *base, *k, *p, *t;
+
+	if (nmemb <= 1)
+		return (0);
+
+	if (!size) {
+		errno = EINVAL;
+		return (-1);
+	}
+
+	if (compar == NULL) {
+		errno = EINVAL;
+		return (-2);
+	}
+
+	if ((k = malloc(size)) == NULL)
+		return (-3);
+
+	/*
+	 * Items are numbered from 1 to nmemb, so offset from size bytes
+	 * below the starting address.
+	 */
+	base = (char *)vbase - size;
+
+	for (l = (nmemb >> 1); l > 0; l--) {
+	    i = l;
+	    BOTTOM_UP_REHEAP(nmemb, i);
+	}
+
+	/*
+	 * For each element of the heap, leave the largest in its final slot,
+	 * then recreate the heap.
+	 */
+	while (nmemb > 1) {
+	    p = base + size;
+	    t = base + size * nmemb;
+	    SWAP(t, p, cnt, size, tmp);
+	    --nmemb;
+	    if (nmemb > 3) {
+		p = base + (l = 2) * size;
+		t = base + 3 * size;
+		if ((*compar)(t, p, arg) > 0) {
+		    p = t;
+		    l = 3;
+		}
+		t = base + size * nmemb;
+		SWAP(t, p, cnt, size, tmp);
+		--nmemb;
+		BOTTOM_UP_REHEAP(nmemb, l);
+	    }
+	    BOTTOM_UP_REHEAP(nmemb, 1);
+	}
+	free(k);
+	return (0);
+}
+
+

--- a/ccan/bottom_up_heapsort/bottom_up_heapsort.h
+++ b/ccan/bottom_up_heapsort/bottom_up_heapsort.h
@@ -1,0 +1,30 @@
+/* 3-clause BSD license - see LICENSE file for details */
+#ifndef CCAN_BOTTOM_UP_HEAPSORT_H
+#define CCAN_BOTTOM_UP_HEAPSORT_H
+#include "config.h"
+#include <ccan/order/order.h>
+#include <stddef.h>
+
+/**
+ * bottom_up_heapsort - sort an array of elements
+ * @base: pointer to data to sort
+ * @num: number of elements
+ * @cmp: pointer to comparison function
+ * @ctx: a context pointer for the cmp function
+ *
+ * This function does a sort on the given array.  The resulting array
+ * will be in ascending sorted order by the provided comparison function.
+ *
+ * The @cmp function should exactly match the type of the @base and
+ * @ctx arguments.  Otherwise it can take three const void *.
+ */
+#define bottom_up_heapsort(base, num, cmp, ctx)				\
+    _bottom_up_heapsort((base), (num), sizeof(*(base)),			\
+			total_order_cast((cmp), *(base), (ctx)), (ctx))
+
+int
+_bottom_up_heapsort(void *base, size_t nmemb, size_t size,
+		    int (*compar)(const void *, const void *, void*), void *arg);
+
+
+#endif /* CCAN_BOTTOM_UP_HEAPSORT_H */

--- a/ccan/bottom_up_heapsort/test/compile_fail-context-type.c
+++ b/ccan/bottom_up_heapsort/test/compile_fail-context-type.c
@@ -1,0 +1,22 @@
+#include <ccan/bottom_up_heapsort/bottom_up_heapsort.h>
+#include <ccan/bottom_up_heapsort/bottom_up_heapsort.c>
+
+static int cmp(char *const *a, char *const *b, int *flag)
+{
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+#ifdef FAIL
+#if HAVE_TYPEOF && HAVE_BUILTIN_CHOOSE_EXPR && HAVE_BUILTIN_TYPES_COMPATIBLE_P
+	char flag;
+#else
+#error "Unfortunately we don't fail if no typecheck_cb support."
+#endif
+#else
+	int flag;
+#endif
+	bottom_up_heapsort(argv+1, argc-1, cmp, &flag);
+	return 0;
+}

--- a/ccan/bottom_up_heapsort/test/run.c
+++ b/ccan/bottom_up_heapsort/test/run.c
@@ -1,0 +1,77 @@
+#include <ccan/bottom_up_heapsort/bottom_up_heapsort.h>
+#include <ccan/bottom_up_heapsort/bottom_up_heapsort.c>
+#include <ccan/array_size/array_size.h>
+#include <ccan/tap/tap.h>
+#include <limits.h>
+#include <stdbool.h>
+
+static int test_cmp( const void *p1, const void *p2, void *arg)
+{
+    const int *i1 = (const int*)p1;
+    const int *i2 = (const int*)p2;
+    int *flag = (int *)arg;
+
+    if (*i1 < *i2) return -1 * *flag;
+    if (*i1 > *i2) return 1 * *flag;
+    
+    return 0;
+}
+
+static bool is_sorted(const int arr[], unsigned int size)
+{
+	unsigned int i;
+
+	for (i = 1; i < size; i++)
+		if (arr[i] < arr[i-1])
+			return false;
+	return true;
+}
+
+static bool is_reverse_sorted(const int arr[], unsigned int size)
+{
+	unsigned int i;
+
+	for (i = 1; i < size; i++)
+		if (arr[i] > arr[i-1])
+			return false;
+	return true;
+}
+
+static void psuedo_random_array(int arr[], unsigned int size)
+{
+	unsigned int i;
+
+	for (i = 0; i < size; i++)
+		arr[i] = i * (INT_MAX / 4 - 7);
+}
+
+#define TEST_SIZE 500
+
+int main(void)
+{
+	int tmparr[TEST_SIZE];
+	int multiplier = 1;
+	int rc;
+
+	plan_tests(9);
+
+	psuedo_random_array(tmparr, TEST_SIZE);
+	ok1(!is_sorted(tmparr, TEST_SIZE));
+	ok1(!is_reverse_sorted(tmparr, TEST_SIZE));
+
+	rc = bottom_up_heapsort(tmparr, TEST_SIZE, &test_cmp, &multiplier);
+	ok1(!rc);
+	ok1(is_sorted(tmparr, TEST_SIZE));
+
+	psuedo_random_array(tmparr, TEST_SIZE);
+	multiplier = -1;
+	rc = bottom_up_heapsort(tmparr, TEST_SIZE, &test_cmp, &multiplier);
+	ok1(!rc);
+	ok1(is_reverse_sorted(tmparr, TEST_SIZE));
+
+	ok1(0 == bottom_up_heapsort(tmparr, 1, &test_cmp, &multiplier));
+	ok1(-1 == _bottom_up_heapsort(tmparr, 2, 0, &test_cmp, &multiplier));
+	ok1(-2 == bottom_up_heapsort(tmparr, 2, NULL, &multiplier));
+	
+	return exit_status();
+}


### PR DESCRIPTION
I have added bottom-up heapsort module implementing a modified version of bottom-up heapsort sorting, see details here: http://blog.dataparksearch.org/397

It is unified with asort() to be typesafe and accept context pointer for comparison function.

Would it better to rename bottom_up_heapsort() into bsort() for function name simplicity?
