### PR TITLE
daemonize: suppres SIGHUP on forking; exit parent without triggering atexit() pr…

### DIFF
--- a/ccan/daemonize/daemonize.c
+++ b/ccan/daemonize/daemonize.c
@@ -2,6 +2,7 @@
 #include <ccan/daemonize/daemonize.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <signal.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -10,13 +11,30 @@
  * Environment. */
 bool daemonize(void)
 {
+        struct sigaction old_sa, sa;
+	const char *dev_null = "/dev/null";
 	pid_t pid;
+	int fd;
+	int sa_rc;
+
+	/* SIGHUP may be thrown when the parent exits below.
+	   So, set to ignore it and save previous action.
+	 */
+        sigemptyset(&sa.sa_mask);
+	sa.sa_handler = SIG_IGN;
+	sa.sa_flags = 0;
+	sa_rc = sigaction(SIGHUP, &sa, &old_sa);
 
 	/* Separate from our parent via fork, so init inherits us. */
 	if ((pid = fork()) < 0)
 		return false;
+	/* use _exit() to avoid triggering atexit() processing */
 	if (pid != 0)
-		exit(0);
+		_exit(0);
+
+	/* Restore previous SIGHUP action. */
+        if (sa_rc != -1)
+	        sigaction(SIGHUP, &old_sa, NULL);
 
 	/* Don't hold files open. */
 	close(STDIN_FILENO);
@@ -25,14 +43,25 @@ bool daemonize(void)
 
 	/* Many routines write to stderr; that can cause chaos if used
 	 * for something else, so set it here. */
-	if (open("/dev/null", O_WRONLY) != 0)
+	/* reopen STDIN */
+	if ((fd = open(dev_null, O_RDONLY)) == -1)
 		return false;
-	if (dup2(0, STDERR_FILENO) != STDERR_FILENO)
+	if (dup2(fd, STDIN_FILENO) != STDIN_FILENO)
+	        return false;
+	if (fd > STDERR_FILENO) close(fd);
+	/* reopen STDOUT */
+	if ((fd = open("/dev/null", O_WRONLY)) == -1)
 		return false;
-	close(0);
+	if (dup2(fd, STDOUT_FILENO) != STDOUT_FILENO)
+	        return false;
+	/* reopen STDERR */
+	if (dup2(fd, STDERR_FILENO) != STDERR_FILENO)
+		return false;
+	if (fd > STDERR_FILENO) close(fd);
 
 	/* Session leader so ^C doesn't whack us. */
-	setsid();
+	if (setsid() == (pid_t)-1)
+	        return false;
 	/* Move off any mount points we might be in. */
 	if (chdir("/") != 0)
 		return false;

--- a/ccan/daemonize/test/run.c
+++ b/ccan/daemonize/test/run.c
@@ -68,8 +68,8 @@ int main(int argc, char *argv[])
 	ok1(daemonized.ppid == 1);
 #endif
 	ok1(daemonized.in_root_dir);
-	ok1(daemonized.read_from_stdin == EBADF);
-	ok1(daemonized.write_to_stdout == EBADF);
+	ok1(daemonized.read_from_stdin == 0);
+	ok1(daemonized.write_to_stdout == 0);
 	ok1(daemonized.write_to_stderr == 0);
 
 	return exit_status();


### PR DESCRIPTION
…ocessing; reopen STDIN and STDOUT as dev/null; check setsid() return value.

- We need to suppress SIGHUP until we set up as the parent's exit on forking would throw it.
- It is better to use _exit() on parent termination as it doesn't trigger atexit() processing which would be processed when daemon terminates normal way.
- It is better to reopen STDIN and STDOUT as well as they may be used in a third-party application using ccan.
- Check setsid() return value and return false if it's failed.