### PR TITLE
exit parent without triggering atexit() processing

### DIFF
--- a/ccan/daemonize/daemonize.c
+++ b/ccan/daemonize/daemonize.c
@@ -15,8 +15,9 @@ bool daemonize(void)
 	/* Separate from our parent via fork, so init inherits us. */
 	if ((pid = fork()) < 0)
 		return false;
+	/* use _exit() to avoid triggering atexit() processing */
 	if (pid != 0)
-		exit(0);
+		_exit(0);
 
 	/* Don't hold files open. */
 	close(STDIN_FILENO);


### PR DESCRIPTION
It is better to use _exit() on parent termination as it doesn't trigger atexit() processing which would be processed when daemon terminates normal way.
