### PR TITLE
cflags support for _info, ccanlint builds strgrp with -fopenmp

### DIFF
--- a/ccan/strgrp/_info
+++ b/ccan/strgrp/_info
@@ -103,5 +103,12 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
+#if HAVE_OPENMP
+    if (strcmp(argv[1], "cflags") == 0) {
+        printf("-fopenmp\n");
+        return 0;
+    }
+#endif
+
     return 1;
 }

--- a/ccan/strgrp/strgrp.c
+++ b/ccan/strgrp/strgrp.c
@@ -25,6 +25,7 @@
 #include "ccan/tal/tal.h"
 #include "ccan/tal/str/str.h"
 #include "strgrp.h"
+#include "config.h"
 
 typedef darray(struct strgrp_grp *) darray_grp;
 typedef darray(struct strgrp_item *) darray_item;
@@ -224,7 +225,10 @@ grp_for(struct strgrp *const ctx, const char *const str) {
         }
     }
     int i;
+// Keep ccanlint happy in reduced feature mode
+#if HAVE_OPENMP
     #pragma omp parallel for schedule(dynamic)
+#endif
     for (i = 0; i < ctx->n_grps; i++) {
         ctx->scores[i].grp = darray_item(ctx->grps, i);
         const bool ss = should_grp_score(ctx, ctx->scores[i].grp, str);

--- a/tools/ccanlint/tests/examples_compile.c
+++ b/tools/ccanlint/tests/examples_compile.c
@@ -126,6 +126,17 @@ static char *example_lib_list(const void *ctx, struct manifest **deps)
 	return list;
 }
 
+static char *cflags_list(const struct manifest *m)
+{
+	unsigned int i;
+	char *ret = tal_strdup(m, cflags);
+
+	char **flags = get_cflags(m, m->dir, get_or_compile_info);
+	for (i = 0; flags[i]; i++)
+		tal_append_fmt(&ret, " %s", flags[i]);
+	return ret;
+}
+
 /* FIXME: Test with reduced features! */
 static bool compile(const void *ctx,
 		    struct manifest *m,
@@ -133,11 +144,12 @@ static bool compile(const void *ctx,
 		    char **output)
 {
 	struct manifest **deps = get_example_deps(m, file);
+	const char *flags = cflags_list(m);
 
 	file->compiled[COMPILE_NORMAL] = temp_file(ctx, "", file->fullname);
 	if (!compile_and_link(ctx, file->fullname, ccan_dir,
 			      example_obj_list(file, deps),
-			      compiler, cflags,
+			      compiler, flags,
 			      example_lib_list(file, deps),
 			      file->compiled[COMPILE_NORMAL],
 			      output)) {

--- a/tools/ccanlint/tests/module_links.c
+++ b/tools/ccanlint/tests/module_links.c
@@ -41,6 +41,17 @@ static char *obj_list(const struct manifest *m)
 	return list;
 }
 
+static char *cflags_list(const struct manifest *m)
+{
+	unsigned int i;
+	char *ret = tal_strdup(m, cflags);
+
+	char **flags = get_cflags(m, m->dir, get_or_compile_info);
+	for (i = 0; flags[i]; i++)
+		tal_append_fmt(&ret, " %s", flags[i]);
+	return ret;
+}
+
 static char *lib_list(const struct manifest *m)
 {
 	unsigned int i;
@@ -59,6 +70,7 @@ static void check_use_build(struct manifest *m,
 	char *contents;
 	char *tmpfile, *cmdout;
 	int fd;
+	char *flags;
 
 	tmpfile = temp_file(m, ".c", "example.c");
 
@@ -77,8 +89,10 @@ static void check_use_build(struct manifest *m,
 		err(1, "Failure writing to temporary file %s", tmpfile);
 	close(fd);
 
+	flags = cflags_list(m);
+
 	if (compile_and_link(score, tmpfile, ccan_dir, obj_list(m),
-			     compiler, cflags, lib_list(m),
+			     compiler, flags, lib_list(m),
 			     temp_file(m, "", tmpfile),
 			     &cmdout)) {
 		score->pass = true;

--- a/tools/ccanlint/tests/objects_build.c
+++ b/tools/ccanlint/tests/objects_build.c
@@ -22,6 +22,17 @@ static const char *can_build(struct manifest *m)
 	return NULL;
 }
 
+static char *cflags_list(const struct manifest *m)
+{
+	unsigned int i;
+	char *ret = tal_strdup(m, cflags);
+
+	char **flags = get_cflags(m, m->dir, get_or_compile_info);
+	for (i = 0; flags[i]; i++)
+		tal_append_fmt(&ret, " %s", flags[i]);
+	return ret;
+}
+
 void build_objects(struct manifest *m,
 		   struct score *score, const char *flags,
 		   enum compile_type ctype)
@@ -65,7 +76,10 @@ void build_objects(struct manifest *m,
 static void check_objs_build(struct manifest *m,
 			     unsigned int *timeleft, struct score *score)
 {
-	build_objects(m, score, cflags, COMPILE_NORMAL);
+	const char *flags;
+
+	flags = cflags_list(m);
+	build_objects(m, score, flags, COMPILE_NORMAL);
 }
 
 struct ccanlint objects_build = {

--- a/tools/ccanlint/tests/tests_compile.c
+++ b/tools/ccanlint/tests/tests_compile.c
@@ -66,6 +66,17 @@ char *test_lib_list(const struct manifest *m, enum compile_type ctype)
 	return ret;
 }
 
+static char *cflags_list(const struct manifest *m, const char *iflags)
+{
+	unsigned int i;
+	char *ret = tal_strdup(m, iflags);
+
+	char **flags = get_cflags(m, m->dir, get_or_compile_info);
+	for (i = 0; flags[i]; i++)
+		tal_append_fmt(&ret, " %s", flags[i]);
+	return ret;
+}
+
 static bool compile(const void *ctx,
 		    struct manifest *m,
 		    struct ccan_file *file,
@@ -81,6 +92,7 @@ static bool compile(const void *ctx,
 			cflags,
 			ctype == COMPILE_NOFEAT
 			? " "REDUCE_FEATURES_FLAGS : "");
+	flags = cflags_list(m, flags);
 
 	fname = temp_file(ctx, "", file->fullname);
 	if (!compile_and_link(ctx, file->fullname, ccan_dir,
@@ -110,6 +122,7 @@ static void compile_async(const void *ctx,
 			cflags,
 			ctype == COMPILE_NOFEAT
 			? " "REDUCE_FEATURES_FLAGS : "");
+	flags = cflags_list(m, flags);
 
 	compile_and_link_async(file, time_ms, file->fullname, ccan_dir,
 			       test_obj_list(m, link_with_module, ctype, ctype),

--- a/tools/depends.c
+++ b/tools/depends.c
@@ -228,17 +228,29 @@ get_all_deps(const void *ctx, const char *dir, const char *style,
 }
 
 /* Can return NULL: _info may not support 'libs'. */
-static char **get_one_libs(const void *ctx, const char *dir,
+static char **get_one_prop(const void *ctx, const char *dir, const char *prop,
 			   char *(*get_info)(const void *ctx, const char *dir))
 {
 	char *cmd, **lines;
 
-	cmd = tal_fmt(ctx, "%s libs", get_info(ctx, dir));
+	cmd = tal_fmt(ctx, "%s %s", get_info(ctx, dir), prop);
 	lines = lines_from_cmd(cmd, "%s", cmd);
 	/* Strip final NULL. */
 	if (lines)
 		tal_resize(&lines, tal_count(lines)-1);
 	return lines;
+}
+
+static char **get_one_libs(const void *ctx, const char *dir,
+			   char *(*get_info)(const void *ctx, const char *dir))
+{
+	return get_one_prop(ctx, dir, "libs", get_info);
+}
+
+static char **get_one_cflags(const void *ctx, const char *dir,
+			   char *(*get_info)(const void *ctx, const char *dir))
+{
+	return get_one_prop(ctx, dir, "cflags", get_info);
 }
 
 /* O(n^2) but n is small. */
@@ -256,6 +268,18 @@ static char **add_deps(char **deps1, char **deps2)
 		deps1[len++] = NULL;
 	}
 	return deps1;
+}
+
+char **get_cflags(const void *ctx, const char *dir,
+        char *(*get_info)(const void *ctx, const char *dir))
+{
+	char **flags;
+	unsigned int len;
+	flags = get_one_cflags(ctx, dir, get_info);
+	len = tal_count(flags);
+	tal_resize(&flags, len + 1);
+	flags[len] = NULL;
+	return flags;
 }
 
 char **get_libs(const void *ctx, const char *dir, const char *style,

--- a/tools/tools.h
+++ b/tools/tools.h
@@ -43,6 +43,9 @@ char **get_safe_ccan_deps(const void *ctx, const char *dir, const char *style,
 char **get_libs(const void *ctx, const char *dir, const char *style,
 		char *(*get_info)(const void *ctx, const char *dir));
 
+char **get_cflags(const void *ctx, const char *dir,
+		char *(*get_info)(const void *ctx, const char *dir));
+
 /* From tools.c */
 /* If set, print all commands run, all output they give and exit status. */
 extern bool tools_verbose;


### PR DESCRIPTION
As discussed [PR29](https://github.com/rustyrussell/ccan/pull/29). I couldn't resist cleaning up the leak and unused parameter, though the copy/paste still exists (however this seems to fit existing patterns). Also fixed the formatting to match the rest of the ccanlint code.