### PR TITLE
Ensure config.h is created before the main travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ addons:
             - libjudy-dev libvorbis-dev libportaudio-dev libtalloc-dev
 
 script:
+        - make config.h
         - make -j2
         - make -j2 -k check


### PR DESCRIPTION
The current makefiles are not parallel safe and reliably fail on the
clang build. The real fix is to rewrite the makefiles, but in the
meantime, allow the clang tests to pass.