### PR TITLE
Add a SHA512 implementation

### DIFF
--- a/Makefile-ccan
+++ b/Makefile-ccan
@@ -42,6 +42,7 @@ MODS := a_star \
 	crcsync \
 	crypto/ripemd160 \
 	crypto/sha256 \
+	crypto/sha512 \
 	crypto/shachain \
 	crypto/siphash24 \
 	daemonize \

--- a/ccan/crypto/sha512/LICENSE
+++ b/ccan/crypto/sha512/LICENSE
@@ -1,0 +1,1 @@
+../../../licenses/BSD-MIT

--- a/ccan/crypto/sha512/_info
+++ b/ccan/crypto/sha512/_info
@@ -1,0 +1,61 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * crypto/sha512 - implementation of SHA-2 with 512 bit digest.
+ *
+ * This code is either a wrapper for openssl (if CCAN_CRYPTO_SHA512_USE_OPENSSL
+ * is defined) or an open-coded implementation based on Bitcoin's.
+ *
+ * License: BSD-MIT
+ * Maintainer: Rusty Russell <rusty@rustcorp.com.au>
+ *
+ * Example:
+ *	#include <ccan/crypto/sha512/sha512.h>
+ *	#include <err.h>
+ *	#include <stdio.h>
+ *	#include <string.h>
+ *
+ *	// Simple demonstration: identical strings will have the same hash, but
+ *	// two different strings will not.
+ *	int main(int argc, char *argv[])
+ *	{
+ *		struct sha512 hash1, hash2;
+ *
+ *		if (argc != 3)
+ *			errx(1, "Usage: %s <string1> <string2>", argv[0]);
+ *
+ *		sha512(&hash1, argv[1], strlen(argv[1]));
+ *		sha512(&hash2, argv[2], strlen(argv[2]));
+ *		printf("Hash is %s\n", memcmp(&hash1, &hash2, sizeof(hash1))
+ *			? "different" : "same");
+ *		return 0;
+ *	}
+ */
+int main(int argc, char *argv[])
+{
+	/* Expect exactly one argument */
+	if (argc != 2)
+		return 1;
+
+	if (strcmp(argv[1], "depends") == 0) {
+		printf("ccan/compiler\n");
+		printf("ccan/endian\n");
+		return 0;
+	}
+
+	if (strcmp(argv[1], "testdepends") == 0) {
+		printf("ccan/str/hex\n");
+		return 0;
+	}
+
+	if (strcmp(argv[1], "libs") == 0) {
+#ifdef CCAN_CRYPTO_SHA512_USE_OPENSSL
+		printf("crypto\n");
+#endif
+		return 0;
+	}
+
+	return 1;
+}

--- a/ccan/crypto/sha512/sha512.c
+++ b/ccan/crypto/sha512/sha512.c
@@ -1,0 +1,268 @@
+/* MIT (BSD) license - see LICENSE file for details */
+/* SHA512 core code translated from the Bitcoin project's C++:
+ *
+ * src/crypto/sha512.cpp commit f914f1a746d7f91951c1da262a4a749dd3ebfa71
+ * Copyright (c) 2014 The Bitcoin Core developers
+ * Distributed under the MIT software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ */
+#include <ccan/crypto/sha512/sha512.h>
+#include <ccan/endian/endian.h>
+#include <ccan/compiler/compiler.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <string.h>
+
+static void invalidate_sha512(struct sha512_ctx *ctx)
+{
+#ifdef CCAN_CRYPTO_SHA512_USE_OPENSSL
+	ctx->c.md_len = 0;
+#else
+	ctx->bytes = (size_t)-1;
+#endif
+}
+
+static void check_sha512(struct sha512_ctx *ctx UNUSED)
+{
+#ifdef CCAN_CRYPTO_SHA512_USE_OPENSSL
+	assert(ctx->c.md_len != 0);
+#else
+	assert(ctx->bytes != (size_t)-1);
+#endif
+}
+
+#ifdef CCAN_CRYPTO_SHA512_USE_OPENSSL
+void sha512_init(struct sha512_ctx *ctx)
+{
+	SHA512_Init(&ctx->c);
+}
+
+void sha512_update(struct sha512_ctx *ctx, const void *p, size_t size)
+{
+	check_sha512(ctx);
+	SHA512_Update(&ctx->c, p, size);
+}
+
+void sha512_done(struct sha512_ctx *ctx, struct sha512 *res)
+{
+	SHA512_Final(res->u.u8, &ctx->c);
+	invalidate_sha512(ctx);
+}
+#else
+static uint64_t Ch(uint64_t x, uint64_t y, uint64_t z)
+{
+	return z ^ (x & (y ^ z));
+}
+static uint64_t Maj(uint64_t x, uint64_t y, uint64_t z)
+{
+	return (x & y) | (z & (x | y));
+}
+static uint64_t Sigma0(uint64_t x)
+{
+	return (x >> 28 | x << 36) ^ (x >> 34 | x << 30) ^ (x >> 39 | x << 25);
+}
+static uint64_t Sigma1(uint64_t x)
+{
+	return (x >> 14 | x << 50) ^ (x >> 18 | x << 46) ^ (x >> 41 | x << 23);
+}
+static uint64_t sigma0(uint64_t x)
+{
+	return (x >> 1 | x << 63) ^ (x >> 8 | x << 56) ^ (x >> 7);
+}
+static uint64_t sigma1(uint64_t x)
+{
+	return (x >> 19 | x << 45) ^ (x >> 61 | x << 3) ^ (x >> 6);
+}
+
+/** One round of SHA-512. */
+static void Round(uint64_t a, uint64_t b, uint64_t c, uint64_t *d, uint64_t e, uint64_t f, uint64_t g, uint64_t *h, uint64_t k, uint64_t w)
+{
+	uint64_t t1 = *h + Sigma1(e) + Ch(e, f, g) + k + w;
+	uint64_t t2 = Sigma0(a) + Maj(a, b, c);
+	*d += t1;
+	*h = t1 + t2;
+}
+
+/** Perform one SHA-512 transformation, processing a 128-byte chunk. */
+static void Transform(uint64_t *s, const uint64_t *chunk)
+{
+	uint64_t a = s[0], b = s[1], c = s[2], d = s[3], e = s[4], f = s[5], g = s[6], h = s[7];
+	uint64_t w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14, w15;
+
+	Round(a, b, c, &d, e, f, g, &h, 0x428a2f98d728ae22ull, w0 = be64_to_cpu(chunk[0]));
+	Round(h, a, b, &c, d, e, f, &g, 0x7137449123ef65cdull, w1 = be64_to_cpu(chunk[1]));
+	Round(g, h, a, &b, c, d, e, &f, 0xb5c0fbcfec4d3b2full, w2 = be64_to_cpu(chunk[2]));
+	Round(f, g, h, &a, b, c, d, &e, 0xe9b5dba58189dbbcull, w3 = be64_to_cpu(chunk[3]));
+	Round(e, f, g, &h, a, b, c, &d, 0x3956c25bf348b538ull, w4 = be64_to_cpu(chunk[4]));
+	Round(d, e, f, &g, h, a, b, &c, 0x59f111f1b605d019ull, w5 = be64_to_cpu(chunk[5]));
+	Round(c, d, e, &f, g, h, a, &b, 0x923f82a4af194f9bull, w6 = be64_to_cpu(chunk[6]));
+	Round(b, c, d, &e, f, g, h, &a, 0xab1c5ed5da6d8118ull, w7 = be64_to_cpu(chunk[7]));
+	Round(a, b, c, &d, e, f, g, &h, 0xd807aa98a3030242ull, w8 = be64_to_cpu(chunk[8]));
+	Round(h, a, b, &c, d, e, f, &g, 0x12835b0145706fbeull, w9 = be64_to_cpu(chunk[9]));
+	Round(g, h, a, &b, c, d, e, &f, 0x243185be4ee4b28cull, w10 = be64_to_cpu(chunk[10]));
+	Round(f, g, h, &a, b, c, d, &e, 0x550c7dc3d5ffb4e2ull, w11 = be64_to_cpu(chunk[11]));
+	Round(e, f, g, &h, a, b, c, &d, 0x72be5d74f27b896full, w12 = be64_to_cpu(chunk[12]));
+	Round(d, e, f, &g, h, a, b, &c, 0x80deb1fe3b1696b1ull, w13 = be64_to_cpu(chunk[13]));
+	Round(c, d, e, &f, g, h, a, &b, 0x9bdc06a725c71235ull, w14 = be64_to_cpu(chunk[14]));
+	Round(b, c, d, &e, f, g, h, &a, 0xc19bf174cf692694ull, w15 = be64_to_cpu(chunk[15]));
+
+	Round(a, b, c, &d, e, f, g, &h, 0xe49b69c19ef14ad2ull, w0 += sigma1(w14) + w9 + sigma0(w1));
+	Round(h, a, b, &c, d, e, f, &g, 0xefbe4786384f25e3ull, w1 += sigma1(w15) + w10 + sigma0(w2));
+	Round(g, h, a, &b, c, d, e, &f, 0x0fc19dc68b8cd5b5ull, w2 += sigma1(w0) + w11 + sigma0(w3));
+	Round(f, g, h, &a, b, c, d, &e, 0x240ca1cc77ac9c65ull, w3 += sigma1(w1) + w12 + sigma0(w4));
+	Round(e, f, g, &h, a, b, c, &d, 0x2de92c6f592b0275ull, w4 += sigma1(w2) + w13 + sigma0(w5));
+	Round(d, e, f, &g, h, a, b, &c, 0x4a7484aa6ea6e483ull, w5 += sigma1(w3) + w14 + sigma0(w6));
+	Round(c, d, e, &f, g, h, a, &b, 0x5cb0a9dcbd41fbd4ull, w6 += sigma1(w4) + w15 + sigma0(w7));
+	Round(b, c, d, &e, f, g, h, &a, 0x76f988da831153b5ull, w7 += sigma1(w5) + w0 + sigma0(w8));
+	Round(a, b, c, &d, e, f, g, &h, 0x983e5152ee66dfabull, w8 += sigma1(w6) + w1 + sigma0(w9));
+	Round(h, a, b, &c, d, e, f, &g, 0xa831c66d2db43210ull, w9 += sigma1(w7) + w2 + sigma0(w10));
+	Round(g, h, a, &b, c, d, e, &f, 0xb00327c898fb213full, w10 += sigma1(w8) + w3 + sigma0(w11));
+	Round(f, g, h, &a, b, c, d, &e, 0xbf597fc7beef0ee4ull, w11 += sigma1(w9) + w4 + sigma0(w12));
+	Round(e, f, g, &h, a, b, c, &d, 0xc6e00bf33da88fc2ull, w12 += sigma1(w10) + w5 + sigma0(w13));
+	Round(d, e, f, &g, h, a, b, &c, 0xd5a79147930aa725ull, w13 += sigma1(w11) + w6 + sigma0(w14));
+	Round(c, d, e, &f, g, h, a, &b, 0x06ca6351e003826full, w14 += sigma1(w12) + w7 + sigma0(w15));
+	Round(b, c, d, &e, f, g, h, &a, 0x142929670a0e6e70ull, w15 += sigma1(w13) + w8 + sigma0(w0));
+
+	Round(a, b, c, &d, e, f, g, &h, 0x27b70a8546d22ffcull, w0 += sigma1(w14) + w9 + sigma0(w1));
+	Round(h, a, b, &c, d, e, f, &g, 0x2e1b21385c26c926ull, w1 += sigma1(w15) + w10 + sigma0(w2));
+	Round(g, h, a, &b, c, d, e, &f, 0x4d2c6dfc5ac42aedull, w2 += sigma1(w0) + w11 + sigma0(w3));
+	Round(f, g, h, &a, b, c, d, &e, 0x53380d139d95b3dfull, w3 += sigma1(w1) + w12 + sigma0(w4));
+	Round(e, f, g, &h, a, b, c, &d, 0x650a73548baf63deull, w4 += sigma1(w2) + w13 + sigma0(w5));
+	Round(d, e, f, &g, h, a, b, &c, 0x766a0abb3c77b2a8ull, w5 += sigma1(w3) + w14 + sigma0(w6));
+	Round(c, d, e, &f, g, h, a, &b, 0x81c2c92e47edaee6ull, w6 += sigma1(w4) + w15 + sigma0(w7));
+	Round(b, c, d, &e, f, g, h, &a, 0x92722c851482353bull, w7 += sigma1(w5) + w0 + sigma0(w8));
+	Round(a, b, c, &d, e, f, g, &h, 0xa2bfe8a14cf10364ull, w8 += sigma1(w6) + w1 + sigma0(w9));
+	Round(h, a, b, &c, d, e, f, &g, 0xa81a664bbc423001ull, w9 += sigma1(w7) + w2 + sigma0(w10));
+	Round(g, h, a, &b, c, d, e, &f, 0xc24b8b70d0f89791ull, w10 += sigma1(w8) + w3 + sigma0(w11));
+	Round(f, g, h, &a, b, c, d, &e, 0xc76c51a30654be30ull, w11 += sigma1(w9) + w4 + sigma0(w12));
+	Round(e, f, g, &h, a, b, c, &d, 0xd192e819d6ef5218ull, w12 += sigma1(w10) + w5 + sigma0(w13));
+	Round(d, e, f, &g, h, a, b, &c, 0xd69906245565a910ull, w13 += sigma1(w11) + w6 + sigma0(w14));
+	Round(c, d, e, &f, g, h, a, &b, 0xf40e35855771202aull, w14 += sigma1(w12) + w7 + sigma0(w15));
+	Round(b, c, d, &e, f, g, h, &a, 0x106aa07032bbd1b8ull, w15 += sigma1(w13) + w8 + sigma0(w0));
+
+	Round(a, b, c, &d, e, f, g, &h, 0x19a4c116b8d2d0c8ull, w0 += sigma1(w14) + w9 + sigma0(w1));
+	Round(h, a, b, &c, d, e, f, &g, 0x1e376c085141ab53ull, w1 += sigma1(w15) + w10 + sigma0(w2));
+	Round(g, h, a, &b, c, d, e, &f, 0x2748774cdf8eeb99ull, w2 += sigma1(w0) + w11 + sigma0(w3));
+	Round(f, g, h, &a, b, c, d, &e, 0x34b0bcb5e19b48a8ull, w3 += sigma1(w1) + w12 + sigma0(w4));
+	Round(e, f, g, &h, a, b, c, &d, 0x391c0cb3c5c95a63ull, w4 += sigma1(w2) + w13 + sigma0(w5));
+	Round(d, e, f, &g, h, a, b, &c, 0x4ed8aa4ae3418acbull, w5 += sigma1(w3) + w14 + sigma0(w6));
+	Round(c, d, e, &f, g, h, a, &b, 0x5b9cca4f7763e373ull, w6 += sigma1(w4) + w15 + sigma0(w7));
+	Round(b, c, d, &e, f, g, h, &a, 0x682e6ff3d6b2b8a3ull, w7 += sigma1(w5) + w0 + sigma0(w8));
+	Round(a, b, c, &d, e, f, g, &h, 0x748f82ee5defb2fcull, w8 += sigma1(w6) + w1 + sigma0(w9));
+	Round(h, a, b, &c, d, e, f, &g, 0x78a5636f43172f60ull, w9 += sigma1(w7) + w2 + sigma0(w10));
+	Round(g, h, a, &b, c, d, e, &f, 0x84c87814a1f0ab72ull, w10 += sigma1(w8) + w3 + sigma0(w11));
+	Round(f, g, h, &a, b, c, d, &e, 0x8cc702081a6439ecull, w11 += sigma1(w9) + w4 + sigma0(w12));
+	Round(e, f, g, &h, a, b, c, &d, 0x90befffa23631e28ull, w12 += sigma1(w10) + w5 + sigma0(w13));
+	Round(d, e, f, &g, h, a, b, &c, 0xa4506cebde82bde9ull, w13 += sigma1(w11) + w6 + sigma0(w14));
+	Round(c, d, e, &f, g, h, a, &b, 0xbef9a3f7b2c67915ull, w14 += sigma1(w12) + w7 + sigma0(w15));
+	Round(b, c, d, &e, f, g, h, &a, 0xc67178f2e372532bull, w15 += sigma1(w13) + w8 + sigma0(w0));
+
+	Round(a, b, c, &d, e, f, g, &h, 0xca273eceea26619cull, w0 += sigma1(w14) + w9 + sigma0(w1));
+	Round(h, a, b, &c, d, e, f, &g, 0xd186b8c721c0c207ull, w1 += sigma1(w15) + w10 + sigma0(w2));
+	Round(g, h, a, &b, c, d, e, &f, 0xeada7dd6cde0eb1eull, w2 += sigma1(w0) + w11 + sigma0(w3));
+	Round(f, g, h, &a, b, c, d, &e, 0xf57d4f7fee6ed178ull, w3 += sigma1(w1) + w12 + sigma0(w4));
+	Round(e, f, g, &h, a, b, c, &d, 0x06f067aa72176fbaull, w4 += sigma1(w2) + w13 + sigma0(w5));
+	Round(d, e, f, &g, h, a, b, &c, 0x0a637dc5a2c898a6ull, w5 += sigma1(w3) + w14 + sigma0(w6));
+	Round(c, d, e, &f, g, h, a, &b, 0x113f9804bef90daeull, w6 += sigma1(w4) + w15 + sigma0(w7));
+	Round(b, c, d, &e, f, g, h, &a, 0x1b710b35131c471bull, w7 += sigma1(w5) + w0 + sigma0(w8));
+	Round(a, b, c, &d, e, f, g, &h, 0x28db77f523047d84ull, w8 += sigma1(w6) + w1 + sigma0(w9));
+	Round(h, a, b, &c, d, e, f, &g, 0x32caab7b40c72493ull, w9 += sigma1(w7) + w2 + sigma0(w10));
+	Round(g, h, a, &b, c, d, e, &f, 0x3c9ebe0a15c9bebcull, w10 += sigma1(w8) + w3 + sigma0(w11));
+	Round(f, g, h, &a, b, c, d, &e, 0x431d67c49c100d4cull, w11 += sigma1(w9) + w4 + sigma0(w12));
+	Round(e, f, g, &h, a, b, c, &d, 0x4cc5d4becb3e42b6ull, w12 += sigma1(w10) + w5 + sigma0(w13));
+	Round(d, e, f, &g, h, a, b, &c, 0x597f299cfc657e2aull, w13 += sigma1(w11) + w6 + sigma0(w14));
+	Round(c, d, e, &f, g, h, a, &b, 0x5fcb6fab3ad6faecull, w14 + sigma1(w12) + w7 + sigma0(w15));
+	Round(b, c, d, &e, f, g, h, &a, 0x6c44198c4a475817ull, w15 + sigma1(w13) + w8 + sigma0(w0));
+
+	s[0] += a;
+	s[1] += b;
+	s[2] += c;
+	s[3] += d;
+	s[4] += e;
+	s[5] += f;
+	s[6] += g;
+	s[7] += h;
+}
+
+static bool alignment_ok(const void *p UNUSED, size_t n UNUSED)
+{
+#if HAVE_UNALIGNED_ACCESS
+	return true;
+#else
+	return ((size_t)p % n == 0);
+#endif
+}
+
+static void add(struct sha512_ctx *ctx, const void *p, size_t len)
+{
+	const unsigned char *data = p;
+	size_t bufsize = ctx->bytes % 128;
+
+	if (bufsize + len >= 128) {
+		/* Fill the buffer, and process it. */
+		memcpy(ctx->buf.u8 + bufsize, data, 128 - bufsize);
+		ctx->bytes += 128 - bufsize;
+		data += 128 - bufsize;
+		len -= 128 - bufsize;
+		Transform(ctx->s, ctx->buf.u64);
+		bufsize = 0;
+	}
+
+	while (len >= 128) {
+		/* Process full chunks directly from the source. */
+		if (alignment_ok(data, sizeof(uint64_t)))
+			Transform(ctx->s, (const uint64_t *)data);
+		else {
+			memcpy(ctx->buf.u8, data, sizeof(ctx->buf));
+			Transform(ctx->s, ctx->buf.u64);
+		}
+		ctx->bytes += 128;
+		data += 128;
+		len -= 128;
+	}
+
+	if (len) {
+		/* Fill the buffer with what remains. */
+		memcpy(ctx->buf.u8 + bufsize, data, len);
+		ctx->bytes += len;
+	}
+}
+
+void sha512_init(struct sha512_ctx *ctx)
+{
+	struct sha512_ctx init = SHA512_INIT;
+	*ctx = init;
+}
+
+void sha512_update(struct sha512_ctx *ctx, const void *p, size_t size)
+{
+	check_sha512(ctx);
+	add(ctx, p, size);
+}
+
+void sha512_done(struct sha512_ctx *ctx, struct sha512 *res)
+{
+	static const unsigned char pad[128] = { 0x80 };
+	uint64_t sizedesc[2] = { 0, 0 };
+	size_t i;
+
+	sizedesc[1] = cpu_to_be64((uint64_t)ctx->bytes << 3);
+
+	/* Add '1' bit to terminate, then all 0 bits, up to next block - 16. */
+	add(ctx, pad, 1 + ((256 - 16 - (ctx->bytes % 128) - 1) % 128));
+	/* Add number of bits of data (big endian) */
+	add(ctx, sizedesc, sizeof(sizedesc));
+	for (i = 0; i < sizeof(ctx->s) / sizeof(ctx->s[0]); i++)
+		res->u.u64[i] = cpu_to_be64(ctx->s[i]);
+	invalidate_sha512(ctx);
+}
+#endif /* CCAN_CRYPTO_SHA512_USE_OPENSSL */
+
+void sha512(struct sha512 *sha, const void *p, size_t size)
+{
+	struct sha512_ctx ctx;
+
+	sha512_init(&ctx);
+	sha512_update(&ctx, p, size);
+	sha512_done(&ctx, sha);
+}

--- a/ccan/crypto/sha512/sha512.h
+++ b/ccan/crypto/sha512/sha512.h
@@ -1,0 +1,134 @@
+#ifndef CCAN_CRYPTO_SHA512_H
+#define CCAN_CRYPTO_SHA512_H
+/* BSD-MIT - see LICENSE file for details */
+#include "config.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+/* Uncomment this to use openssl's SHA512 routines (and link with -lcrypto) */
+/*#define CCAN_CRYPTO_SHA512_USE_OPENSSL 1*/
+
+#ifdef CCAN_CRYPTO_SHA512_USE_OPENSSL
+#include <openssl/sha.h>
+#endif
+
+/**
+ * struct sha512 - structure representing a completed SHA512.
+ * @u.u8: an unsigned char array.
+ * @u.u64: a 64-bit integer array.
+ *
+ * Other fields may be added to the union in future.
+ */
+struct sha512 {
+	union {
+		uint64_t u64[8];
+		unsigned char u8[64];
+	} u;
+};
+
+/**
+ * sha512 - return sha512 of an object.
+ * @sha512: the sha512 to fill in
+ * @p: pointer to memory,
+ * @size: the number of bytes pointed to by @p
+ *
+ * The bytes pointed to by @p is SHA512 hashed into @sha512.  This is
+ * equivalent to sha512_init(), sha512_update() then sha512_done().
+ */
+void sha512(struct sha512 *sha, const void *p, size_t size);
+
+/**
+ * struct sha512_ctx - structure to store running context for sha512
+ */
+struct sha512_ctx {
+#ifdef CCAN_CRYPTO_SHA512_USE_OPENSSL
+	SHA512_CTX c;
+#else
+	uint64_t s[8];
+	union {
+		uint64_t u64[16];
+		unsigned char u8[128];
+	} buf;
+	size_t bytes;
+#endif
+};
+
+/**
+ * sha512_init - initialize an SHA512 context.
+ * @ctx: the sha512_ctx to initialize
+ *
+ * This must be called before sha512_update or sha512_done, or
+ * alternately you can assign SHA512_INIT.
+ *
+ * If it was already initialized, this forgets anything which was
+ * hashed before.
+ *
+ * Example:
+ * static void hash_all(const char **arr, struct sha512 *hash)
+ * {
+ *	size_t i;
+ *	struct sha512_ctx ctx;
+ *
+ *	sha512_init(&ctx);
+ *	for (i = 0; arr[i]; i++)
+ *		sha512_update(&ctx, arr[i], strlen(arr[i]));
+ *	sha512_done(&ctx, hash);
+ * }
+ */
+void sha512_init(struct sha512_ctx *ctx);
+
+/**
+ * SHA512_INIT - initializer for an SHA512 context.
+ *
+ * This can be used to statically initialize an SHA512 context (instead
+ * of sha512_init()).
+ *
+ * Example:
+ * static void hash_all(const char **arr, struct sha512 *hash)
+ * {
+ *	size_t i;
+ *	struct sha512_ctx ctx = SHA512_INIT;
+ *
+ *	for (i = 0; arr[i]; i++)
+ *		sha512_update(&ctx, arr[i], strlen(arr[i]));
+ *	sha512_done(&ctx, hash);
+ * }
+ */
+#ifdef CCAN_CRYPTO_SHA512_USE_OPENSSL
+#define SHA512_INIT                                           \
+	{ { { 0x6a09e667f3bcc908ull, 0xbb67ae8584caa73bull,   \
+	      0x3c6ef372fe94f82bull, 0xa54ff53a5f1d36f1ull,   \
+	      0x510e527fade682d1ull, 0x9b05688c2b3e6c1full,   \
+	      0x1f83d9abfb41bd6bull, 0x5be0cd19137e2179ull }, \
+	    0, 0, { { 0 } }, 0, 0x40 } }
+#else
+#define SHA512_INIT                                         \
+	{ { 0x6a09e667f3bcc908ull, 0xbb67ae8584caa73bull,   \
+	    0x3c6ef372fe94f82bull, 0xa54ff53a5f1d36f1ull,   \
+	    0x510e527fade682d1ull, 0x9b05688c2b3e6c1full,   \
+	    0x1f83d9abfb41bd6bull, 0x5be0cd19137e2179ull }, \
+	  { { 0 } }, 0 }
+#endif
+
+/**
+ * sha512_update - include some memory in the hash.
+ * @ctx: the sha512_ctx to use
+ * @p: pointer to memory,
+ * @size: the number of bytes pointed to by @p
+ *
+ * You can call this multiple times to hash more data, before calling
+ * sha512_done().
+ */
+void sha512_update(struct sha512_ctx *ctx, const void *p, size_t size);
+
+/**
+ * sha512_done - finish SHA512 and return the hash
+ * @ctx: the sha512_ctx to complete
+ * @res: the hash to return.
+ *
+ * Note that @ctx is *destroyed* by this, and must be reinitialized.
+ * To avoid that, pass a copy instead.
+ */
+void sha512_done(struct sha512_ctx *sha512, struct sha512 *res);
+
+#endif /* CCAN_CRYPTO_SHA512_H */

--- a/ccan/crypto/sha512/test/run-lotsa-data.c
+++ b/ccan/crypto/sha512/test/run-lotsa-data.c
@@ -1,0 +1,23 @@
+#include <ccan/crypto/sha512/sha512.h>
+/* Include the C files directly. */
+#include <ccan/crypto/sha512/sha512.c>
+#include <ccan/tap/tap.h>
+
+int main(void)
+{
+	struct sha512 h, expected;
+	static const char zeroes[1000];
+	size_t i;
+
+	plan_tests(63);
+
+	/* Test different alignments. */
+	sha512(&expected, zeroes, sizeof(zeroes) - 64);
+	for (i = 1; i < 64; i++) {
+		sha512(&h, zeroes + i, sizeof(zeroes) - 64);
+		ok1(memcmp(&h, &expected, sizeof(h)) == 0);
+	}
+
+	/* This exits depending on whether all tests passed */
+	return exit_status();
+}

--- a/ccan/crypto/sha512/test/run-test-vectors.c
+++ b/ccan/crypto/sha512/test/run-test-vectors.c
@@ -1,0 +1,118 @@
+#include <ccan/crypto/sha512/sha512.h>
+#include <ccan/str/hex/hex.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Include the C files directly. */
+#include <ccan/crypto/sha512/sha512.c>
+#include <ccan/tap/tap.h>
+
+/* Test vectors. */
+struct test {
+	const char *vector;
+	size_t repetitions;
+	const char *expected;
+};
+
+static const char ZEROES[] =
+	"0000000000000000000000000000000000000000000000000000000000000000"
+	"0000000000000000000000000000000000000000000000000000000000000000";
+
+static struct test tests[] = {
+	/* http://csrc.nist.gov/groups/STM/cavp/secure-hashing.html ShortMsg */
+	{ "21", 1,
+	  "3831a6a6155e509dee59a7f451eb35324d8f8f2df6e3708894740f98fdee2388"
+	  "9f4de5adb0c5010dfb555cda77c8ab5dc902094c52de3278f35a75ebc25f093a" },
+	{ "9083", 1,
+	  "55586ebba48768aeb323655ab6f4298fc9f670964fc2e5f2731e34dfa4b0c09e"
+	  "6e1e12e3d7286b3145c61c2047fb1a2a1297f36da64160b31fa4c8c2cddd2fb4" },
+	{ "0a55db", 1,
+	  "7952585e5330cb247d72bae696fc8a6b0f7d0804577e347d99bc1b11e52f3849"
+	  "85a428449382306a89261ae143c2f3fb613804ab20b42dc097e5bf4a96ef919b" },
+	{ "23be86d5", 1,
+	  "76d42c8eadea35a69990c63a762f330614a4699977f058adb988f406fb0be8f2"
+	  "ea3dce3a2bbd1d827b70b9b299ae6f9e5058ee97b50bd4922d6d37ddc761f8eb" },
+	{ "eb0ca946c1", 1,
+	  "d39ecedfe6e705a821aee4f58bfc489c3d9433eb4ac1b03a97e321a2586b40dd"
+	  "0522f40fa5aef36afff591a78c916bfc6d1ca515c4983dd8695b1ec7951d723e" },
+	{ "38667f39277b", 1,
+	  "85708b8ff05d974d6af0801c152b95f5fa5c06af9a35230c5bea2752f031f9bd"
+	  "84bd844717b3add308a70dc777f90813c20b47b16385664eefc88449f04f2131" },
+	{ "b39f71aaa8a108", 1,
+	  "258b8efa05b4a06b1e63c7a3f925c5ef11fa03e3d47d631bf4d474983783d8c0"
+	  "b09449009e842fc9fa15de586c67cf8955a17d790b20f41dadf67ee8cdcdfce6" },
+	{ "dc28484ebfd293d62ac759d5754bdf502423e4d419fa79020805134b2ce3dff7"
+	  "38c7556c91d810adbad8dd210f041296b73c2185d4646c97fc0a5b69ed49ac8c"
+	  "7ced0bd1cfd7e3c3cca47374d189247da6811a40b0ab097067ed4ad40ade2e47"
+	  "91e39204e398b3204971445822a1be0dd93af8", 1,
+	  "615115d2e8b62e345adaa4bdb95395a3b4fe27d71c4a111b86c1841463c5f03d"
+	  "6b20d164a39948ab08ae060720d05c10f6022e5c8caf2fa3bca2e04d9c539ded" },
+	{ "fd2203e467574e834ab07c9097ae164532f24be1eb5d88f1af7748ceff0d2c67"
+	  "a21f4e4097f9d3bb4e9fbf97186e0db6db0100230a52b453d421f8ab9c9a6043"
+	  "aa3295ea20d2f06a2f37470d8a99075f1b8a8336f6228cf08b5942fc1fb4299c"
+	  "7d2480e8e82bce175540bdfad7752bc95b577f229515394f3ae5cec870a4b2f8",
+	  1,
+	  "a21b1077d52b27ac545af63b32746c6e3c51cb0cb9f281eb9f3580a6d4996d5c"
+	  "9917d2a6e484627a9d5a06fa1b25327a9d710e027387fc3e07d7c4d14c6086cc" },
+	/* http://www.di-mgt.com.au/sha_testvectors.html */
+	{ ZEROES, 1,
+	  "7be9fda48f4179e611c698a73cff09faf72869431efee6eaad14de0cb44bbf66"
+	  "503f752b7a8eb17083355f3ce6eb7d2806f236b25af96a24e22b887405c20081" }
+#if 0 /* This test is rather slow */
+	,
+	{ ZEROES, 100000,
+	  "23b8521df55569c4e55c7be36d4ad106e338b0799d5e105058aaa1a95737c25d"
+	  "b77af240849ae7283ea0b7cbf196f5e4bd78aca19af97eb6e364ada4d12c1178" }
+#endif
+};
+
+static void *xmalloc(size_t size)
+{
+	char * ret;
+	ret = malloc(size);
+	if (ret == NULL) {
+		perror("malloc");
+		abort();
+	}
+	return ret;
+}
+
+static bool do_test(const struct test *t)
+{
+	struct sha512 h;
+	char got[128 + 1];
+	bool passed;
+	size_t i, vector_len = strlen(t->vector) / 2;
+	void *vector = xmalloc(vector_len);
+
+	hex_decode(t->vector, vector_len * 2, vector, vector_len);
+
+	for (i = 0; i < t->repetitions; i++) {
+		sha512(&h, vector, vector_len);
+		if (t->repetitions > 1)
+			memcpy(vector, &h, sizeof(h));
+	}
+
+	hex_encode(&h, sizeof(h), got, sizeof(got));
+
+	passed = strcmp(t->expected, got) == 0;
+	free(vector);
+	return passed;
+}
+
+int main(void)
+{
+	const size_t num_tests = sizeof(tests) / sizeof(tests[0]);
+	size_t i;
+
+	/* This is how many tests you plan to run */
+	plan_tests(num_tests);
+
+	for (i = 0; i < num_tests; i++)
+		ok1(do_test(&tests[i]));
+
+	/* This exits depending on whether all tests passed */
+	return exit_status();
+}


### PR DESCRIPTION
This largely follows the SHA256 style. I've named Rusty as the maintainer.

Currently the functions to add data of various sizes/endianness have not
been implemented: There are no public test vectors for these cases and
I believe most use cases are working on byte buffers. They can be added
later if desired.

The openssl implementation has been tested on x86-64, while the inbuilt
version has been tested on 32/64 bit, little/big endian boxes.

Signed-off-by: Jon Griffiths <jon_p_griffiths@yahoo.com>