### PR TITLE
base64: fix assignment to wrong type

### DIFF
--- a/ccan/base64/base64.c
+++ b/ccan/base64/base64.c
@@ -118,7 +118,7 @@ size_t base64_decoded_length(size_t srclen)
 	return ((srclen+3)/4*3);
 }
 
-int base64_decode_quartet_using_maps(const base64_maps_t *maps, char dest[3],
+ssize_t base64_decode_quartet_using_maps(const base64_maps_t *maps, char dest[3],
 				     const char src[4])
 {
 	signed char a;
@@ -143,7 +143,7 @@ int base64_decode_quartet_using_maps(const base64_maps_t *maps, char dest[3],
 }
 
 
-int base64_decode_tail_using_maps(const base64_maps_t *maps, char dest[3],
+ssize_t base64_decode_tail_using_maps(const base64_maps_t *maps, char dest[3],
 				  const char * src, const size_t srclen)
 {
 	char longsrc[4];
@@ -178,7 +178,7 @@ ssize_t base64_decode_using_maps(const base64_maps_t *maps,
 {
 	ssize_t dest_offset = 0;
 	ssize_t i;
-	size_t more;
+	ssize_t more;
 
 	if (destlen < base64_decoded_length(srclen)) {
 		errno = EOVERFLOW;

--- a/ccan/base64/base64.h
+++ b/ccan/base64/base64.h
@@ -103,8 +103,8 @@ ssize_t base64_decode_using_maps(const base64_maps_t *maps,
  * @return Number of decoded bytes set in dest. -1 on error (and errno set)
  * @note sets errno = EDOM if src contains invalid characters
  */
-int base64_decode_quartet_using_maps(const base64_maps_t *maps,
-				     char dest[3], const char src[4]);
+ssize_t base64_decode_quartet_using_maps(const base64_maps_t *maps,
+				         char dest[3], const char src[4]);
 
 /**
  * base64_decode_tail_using_maps - decode the final bytes of a base64 string using a specific alphabet
@@ -116,8 +116,8 @@ int base64_decode_quartet_using_maps(const base64_maps_t *maps,
  * @note sets errno = EDOM if src contains invalid characters
  * @note sets errno = EINVAL if src is an invalid base64 tail
  */
-int base64_decode_tail_using_maps(const base64_maps_t *maps, char *dest,
-				  const char *src, size_t srclen);
+ssize_t base64_decode_tail_using_maps(const base64_maps_t *maps, char *dest,
+				      const char *src, size_t srclen);
 
 
 /* the rfc4648 functions: */
@@ -212,7 +212,7 @@ ssize_t base64_decode(char *dest, size_t destlen,
  * @note sets errno = EDOM if src contains invalid characters
  */
 static inline
-int base64_decode_quartet(char dest[3], const char src[4])
+ssize_t base64_decode_quartet(char dest[3], const char src[4])
 {
 	return base64_decode_quartet_using_maps(&base64_maps_rfc4648,
 						dest, src);


### PR DESCRIPTION
Found by gcc:
```
base64.c:196:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  if (more == -1) {
           ^
```