### PR TITLE
Avoid undefined behaviour in memeq(a, al, b, bl) when a, b or both are NULL

### DIFF
--- a/ccan/mem/mem.h
+++ b/ccan/mem/mem.h
@@ -104,7 +104,7 @@ void *memcchr(void const *data, int c, size_t data_len);
 PURE_FUNCTION
 static inline bool memeq(const void *a, size_t al, const void *b, size_t bl)
 {
-	return al == bl && !memcmp(a, b, bl);
+	return al == bl && (bl == 0 || (a != NULL && b != NULL && !memcmp(a, b, bl)));
 }
 
 /**


### PR DESCRIPTION
Avoid undefined behaviour in `memeq(a, al, b, bl)` when `a`, `b` or both are `NULL`.

`memcmp(a, b, bl)` results in undefined behaviour when `a`, `b` or both are `NULL`. This holds also when `bl == 0`.