### PR TITLE
Fix HAVE_ASPRINTF detection

### DIFF
--- a/tools/configurator/configurator.c
+++ b/tools/configurator/configurator.c
@@ -102,7 +102,8 @@ static struct test tests[] = {
 	  "#include <stdio.h>\n"
 	  "static char *func(int x) {"
 	  "	char *p;\n"
-	  "	if (asprintf(&p, \"%u\", x) == -1) p = NULL;"
+	  "	if (asprintf(&p, \"%u\", x) == -1) \n"
+	  "		p = NULL;\n"
 	  "	return p;\n"
 	  "}" },
 	{ "HAVE_ATTRIBUTE_COLD", DEFINES_FUNC, NULL, NULL,


### PR DESCRIPTION
gcc6 introduceed a new warning switched with -Wmisleading-identation. This caused to generate a compilation warning for if statement misleadingly indented, which caused HAVE_ASPRINTF to be defined as 0. Adding newline after an if statement fixes the problem.