### PR TITLE
fix wrong module path in tools/create-ccan-tree

### DIFF
--- a/tools/create-ccan-tree
+++ b/tools/create-ccan-tree
@@ -109,7 +109,7 @@ copy_ccan_module() {
 	# Copy license
 	license="$module_srcdir/LICENSE"
 	[ -e "$license" ] && cp -a "$license" "$module_destdir"
-	for f in $("$modfiles" $MODULES_ARGS --no-license --git-only "$module_dir"); do
+	for f in $("$modfiles" $MODULES_ARGS --no-license --git-only "$module_srcdir"); do
 	    mkdir -p $(dirname "$module_destdir"/"$f")
 	    cp "$module_srcdir"/$f "$module_destdir"/$f
 	done


### PR DESCRIPTION
```bash
$ ./create-ccan-tree -b automake  ~/Desktop/third_party array_size
Building ccan_depends, modfiles
Cleaning source tree
Adding ccan/array_size
modfiles: Getting canonical version of directory ccan/array_size: **No such file or directory**
Adding ccan/build_assert
modfiles: Getting canonical version of directory ccan/build_assert: **No such file or directory**
Adding licenses
Adding build infrastructure
Done. ccan source tree built in /home/peng/Desktop/third_party
```
