### PR TITLE
Fix typos detected by github.com/client9/misspell

### DIFF
--- a/ccan/antithread/examples/arabella.c
+++ b/ccan/antithread/examples/arabella.c
@@ -128,7 +128,7 @@ static void paint_triangle(struct image *image, const struct triangle *tri)
         x1 = tri->coord[i1].x, y1 = tri->coord[i1].y;
         x2 = tri->coord[i2].x, y2 = tri->coord[i2].y;
         
-        // test for easy cases, else split trinagle in two and render both halfs
+        // test for easy cases, else split triangle in two and render both halfs
         if (y1 == y2) {
  		if (x1 > x2) swap(&x1, &x2);
 		add_flat_triangle(image, x1, y1, x2, y2, x0, y0,

--- a/ccan/asort/test/run.c
+++ b/ccan/asort/test/run.c
@@ -35,7 +35,7 @@ static bool is_reverse_sorted(const int arr[], unsigned int size)
 	return true;
 }
 
-static void psuedo_random_array(int arr[], unsigned int size)
+static void pseudo_random_array(int arr[], unsigned int size)
 {
 	unsigned int i;
 
@@ -52,14 +52,14 @@ int main(void)
 
 	plan_tests(4);
 
-	psuedo_random_array(tmparr, TEST_SIZE);
+	pseudo_random_array(tmparr, TEST_SIZE);
 	ok1(!is_sorted(tmparr, TEST_SIZE));
 	ok1(!is_reverse_sorted(tmparr, TEST_SIZE));
 
 	asort(tmparr, TEST_SIZE, test_cmp, &multiplier);
 	ok1(is_sorted(tmparr, TEST_SIZE));
 
-	psuedo_random_array(tmparr, TEST_SIZE);
+	pseudo_random_array(tmparr, TEST_SIZE);
 	multiplier = -1;
 	asort(tmparr, TEST_SIZE, test_cmp, &multiplier);
 	ok1(is_reverse_sorted(tmparr, TEST_SIZE));

--- a/ccan/autodata/autodata.h
+++ b/ccan/autodata/autodata.h
@@ -12,7 +12,7 @@
  * @name: the name for this set of autodata
  * @type: the type this autodata points to
  *
- * This macro is usually placed in a header: it must preceed any
+ * This macro is usually placed in a header: it must precede any
  * autodata functions in the file.
  *
  * Example:

--- a/ccan/bitops/bitops.h
+++ b/ccan/bitops/bitops.h
@@ -15,7 +15,7 @@
 /**
  * bitops_ffs32: find first set bit in a uint32_t
  *
- * Returns 1 for least signficant bit, 32 for most significant bit, 0
+ * Returns 1 for least significant bit, 32 for most significant bit, 0
  * for no bits set.
  */
 static inline int bitops_ffs32(uint32_t u)
@@ -26,7 +26,7 @@ static inline int bitops_ffs32(uint32_t u)
 /**
  * bitops_ffs64: find lowest set bit in a uint64_t
  *
- * Returns 1 for least signficant bit, 32 for most significant bit, 0
+ * Returns 1 for least significant bit, 32 for most significant bit, 0
  * for no bits set.
  */
 static inline int bitops_ffs64(uint64_t u)
@@ -46,8 +46,8 @@ int bitops_ffs64(uint64_t u);
 /**
  * bitops_clz32: count leading zeros in a uint32_t (must not be 0)
  *
- * Returns 0 if most signficant bit is set, 31 if only least
- * signficant bit is set.
+ * Returns 0 if most significant bit is set, 31 if only least
+ * significant bit is set.
  */
 static inline int bitops_clz32(uint32_t u)
 {
@@ -58,8 +58,8 @@ static inline int bitops_clz32(uint32_t u)
 /**
  * bitops_clz64: count leading zeros in a uint64_t (must not be 0)
  *
- * Returns 0 if most signficant bit is set, 63 if only least
- * signficant bit is set.
+ * Returns 0 if most significant bit is set, 63 if only least
+ * significant bit is set.
  */
 static inline int bitops_clz64(uint64_t u)
 {
@@ -79,8 +79,8 @@ int bitops_clz64(uint64_t u);
 /**
  * bitops_ctz32: count trailing zeros in a uint32_t (must not be 0)
  *
- * Returns 0 if least signficant bit is set, 31 if only most
- * signficant bit is set.
+ * Returns 0 if least significant bit is set, 31 if only most
+ * significant bit is set.
  */
 static inline int bitops_ctz32(uint32_t u)
 {
@@ -91,8 +91,8 @@ static inline int bitops_ctz32(uint32_t u)
 /**
  * bitops_ctz64: count trailing zeros in a uint64_t (must not be 0)
  *
- * Returns 0 if least signficant bit is set, 63 if only most
- * signficant bit is set.
+ * Returns 0 if least significant bit is set, 63 if only most
+ * significant bit is set.
  */
 static inline int bitops_ctz64(uint64_t u)
 {
@@ -111,7 +111,7 @@ int bitops_ctz64(uint64_t u);
 /**
  * bitops_ls32: find lowest set bit in a uint32_t (must not be zero)
  *
- * Returns 0 for least signficant bit, 31 for most significant bit.
+ * Returns 0 for least significant bit, 31 for most significant bit.
  */
 static inline int bitops_ls32(uint32_t u)
 {
@@ -122,7 +122,7 @@ static inline int bitops_ls32(uint32_t u)
 /**
  * bitops_ls64: find lowest set bit in a uint64_t (must not be zero)
  *
- * Returns 0 for least signficant bit, 63 for most significant bit.
+ * Returns 0 for least significant bit, 63 for most significant bit.
  */
 static inline int bitops_ls64(uint64_t u)
 {
@@ -133,7 +133,7 @@ static inline int bitops_ls64(uint64_t u)
 /**
  * bitops_hs32: find highest set bit in a uint32_t (must not be zero)
  *
- * Returns 0 for least signficant bit, 31 for most significant bit.
+ * Returns 0 for least significant bit, 31 for most significant bit.
  */
 static inline int bitops_hs32(uint32_t u)
 {
@@ -144,7 +144,7 @@ static inline int bitops_hs32(uint32_t u)
 /**
  * bitops_hs64: find highest set bit in a uint64_t (must not be zero)
  *
- * Returns 0 for least signficant bit, 63 for most significant bit.
+ * Returns 0 for least significant bit, 63 for most significant bit.
  */
 static inline int bitops_hs64(uint64_t u)
 {
@@ -155,7 +155,7 @@ static inline int bitops_hs64(uint64_t u)
 /**
  * bitops_lc32: find lowest clear bit in a uint32_t (must not be 0xFFFFFFFF)
  *
- * Returns 0 for least signficant bit, 31 for most significant bit.
+ * Returns 0 for least significant bit, 31 for most significant bit.
  */
 static inline int bitops_lc32(uint32_t u)
 {
@@ -165,7 +165,7 @@ static inline int bitops_lc32(uint32_t u)
 /**
  * bitops_lc64: find lowest clear bit in a uint64_t (must not be 0xFFFFFFFFFFFFFFFF)
  *
- * Returns 0 for least signficant bit, 63 for most significant bit.
+ * Returns 0 for least significant bit, 63 for most significant bit.
  */
 static inline int bitops_lc64(uint64_t u)
 {
@@ -175,7 +175,7 @@ static inline int bitops_lc64(uint64_t u)
 /**
  * bitops_hc32: find highest clear bit in a uint32_t (must not be 0xFFFFFFFF)
  *
- * Returns 0 for least signficant bit, 31 for most significant bit.
+ * Returns 0 for least significant bit, 31 for most significant bit.
  */
 static inline int bitops_hc32(uint32_t u)
 {
@@ -185,7 +185,7 @@ static inline int bitops_hc32(uint32_t u)
 /**
  * bitops_hc64: find highest clear bit in a uint64_t (must not be 0xFFFFFFFFFFFFFFFF)
  *
- * Returns 0 for least signficant bit, 63 for most significant bit.
+ * Returns 0 for least significant bit, 63 for most significant bit.
  */
 static inline int bitops_hc64(uint64_t u)
 {

--- a/ccan/coroutine/coroutine.c
+++ b/ccan/coroutine/coroutine.c
@@ -17,7 +17,7 @@
  * Stack management
  */
 
-/* Returns lowest stack addres, regardless of growth direction */
+/* Returns lowest stack address, regardless of growth direction */
 static UNNEEDED void *coroutine_stack_base(struct coroutine_stack *stack)
 {
 #if HAVE_STACK_GROWS_UPWARDS

--- a/ccan/crypto/sha256/benchmarks/double-sha-bench.c
+++ b/ccan/crypto/sha256/benchmarks/double-sha-bench.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
 	       block.h.u.u8[3], block.h.u.u8[4], block.h.u.u8[5],
 	       (unsigned long long)time_to_nsec(diff));
 
-	/* Now, don't re-initalize every time; use Transform */
+	/* Now, don't re-initialize every time; use Transform */
 	memset(&block, 0, sizeof(block));
 	sha256(&block.h, &n, sizeof(n));
 	block.u8[sizeof(block.h)] = 0x80;

--- a/ccan/hash/hash.c
+++ b/ccan/hash/hash.c
@@ -281,7 +281,7 @@ static uint32_t hashlittle( const void *key, size_t length, uint32_t *val2 )
      * rest of the string.  Every machine with memory protection I've seen
      * does it on word boundaries, so is OK with this.  But VALGRIND will
      * still catch it and complain.  The masking trick does make the hash
-     * noticably faster for short strings (like English words).
+     * noticeably faster for short strings (like English words).
      *
      * Not on my testing with gcc 4.5 on an intel i5 CPU, at least --RR.
      */
@@ -458,7 +458,7 @@ static uint32_t hashbig( const void *key, size_t length, uint32_t *val2)
      * rest of the string.  Every machine with memory protection I've seen
      * does it on word boundaries, so is OK with this.  But VALGRIND will
      * still catch it and complain.  The masking trick does make the hash
-     * noticably faster for short strings (like English words).
+     * noticeably faster for short strings (like English words).
      *
      * Not on my testing with gcc 4.5 on an intel i5 CPU, at least --RR.
      */

--- a/ccan/intmap/intmap.h
+++ b/ccan/intmap/intmap.h
@@ -286,7 +286,7 @@ void *intmap_first_(const struct intmap *map, intmap_index_t *indexp);
 /**
  * uintmap_after - get the closest following index in an unsigned intmap
  * @umap: the typed intmap to iterate through.
- * @indexp: the preceeding index (may not exist)
+ * @indexp: the preceding index (may not exist)
  *
  * Returns NULL if the there is no entry > @indexp, otherwise
  * populates *@indexp and returns the lowest entry > @indexp.
@@ -300,7 +300,7 @@ void *intmap_after_(const struct intmap *map, intmap_index_t *indexp);
 /**
  * sintmap_after - get the closest following index in a signed intmap
  * @smap: the typed intmap to iterate through.
- * @indexp: the preceeding index (may not exist)
+ * @indexp: the preceding index (may not exist)
  *
  * Returns NULL if the there is no entry > @indexp, otherwise
  * populates *@indexp and returns the lowest entry > @indexp.

--- a/ccan/iscsi/scsi-lowlevel.c
+++ b/ccan/iscsi/scsi-lowlevel.c
@@ -118,7 +118,7 @@ struct scsi_task *scsi_reportluns_cdb(int report_type, int alloc_len)
 }
 
 /*
- * parse the data in blob and calcualte the size of a full report luns datain structure
+ * parse the data in blob and calculate the size of a full report luns datain structure
  */
 static int scsi_reportluns_datain_getfullsize(struct scsi_task *task)
 {
@@ -198,7 +198,7 @@ struct scsi_task *scsi_cdb_readcapacity10(int lba, int pmi)
 }
 
 /*
- * parse the data in blob and calcualte the size of a full readcapacity10 datain structure
+ * parse the data in blob and calculate the size of a full readcapacity10 datain structure
  */
 static int scsi_readcapacity10_datain_getfullsize(struct scsi_task *task
 						  UNUSED)
@@ -268,7 +268,7 @@ struct scsi_task *scsi_cdb_inquiry(int evpd, int page_code, int alloc_len)
 }
 
 /*
- * parse the data in blob and calcualte the size of a full inquiry datain structure
+ * parse the data in blob and calculate the size of a full inquiry datain structure
  */
 static int scsi_inquiry_datain_getfullsize(struct scsi_task *task)
 {
@@ -412,7 +412,7 @@ struct scsi_task *scsi_cdb_modesense6(int dbd, enum scsi_modesense_page_control 
 }
 
 /*
- * parse the data in blob and calcualte the size of a full report luns datain structure
+ * parse the data in blob and calculate the size of a full report luns datain structure
  */
 static int scsi_modesense6_datain_getfullsize(struct scsi_task *task)
 {

--- a/ccan/list/list.h
+++ b/ccan/list/list.h
@@ -708,7 +708,7 @@ static inline void list_prepend_list_(struct list_head *to,
 /**
  * list_for_each_off - iterate through a list of memory regions.
  * @h: the list_head
- * @i: the pointer to a memory region wich contains list node data.
+ * @i: the pointer to a memory region which contains list node data.
  * @off: offset(relative to @i) at which list node data resides.
  *
  * This is a low-level wrapper to iterate @i over the entire list, used to
@@ -740,7 +740,7 @@ static inline void list_prepend_list_(struct list_head *to,
 /**
  * list_for_each_rev_off - iterate through a list of memory regions backwards
  * @h: the list_head
- * @i: the pointer to a memory region wich contains list node data.
+ * @i: the pointer to a memory region which contains list node data.
  * @off: offset(relative to @i) at which list node data resides.
  *
  * See list_for_each_off for details
@@ -752,7 +752,7 @@ static inline void list_prepend_list_(struct list_head *to,
  * list_for_each_safe_off - iterate through a list of memory regions, maybe
  * during deletion
  * @h: the list_head
- * @i: the pointer to a memory region wich contains list node data.
+ * @i: the pointer to a memory region which contains list node data.
  * @nxt: the structure containing the list_node
  * @off: offset(relative to @i) at which list node data resides.
  *
@@ -771,7 +771,7 @@ static inline void list_prepend_list_(struct list_head *to,
  * list_for_each_rev_safe_off - iterate backwards through a list of
  * memory regions, maybe during deletion
  * @h: the list_head
- * @i: the pointer to a memory region wich contains list node data.
+ * @i: the pointer to a memory region which contains list node data.
  * @nxt: the structure containing the list_node
  * @off: offset(relative to @i) at which list node data resides.
  *

--- a/ccan/rbtree/rbtree.c
+++ b/ccan/rbtree/rbtree.c
@@ -448,7 +448,7 @@ delete_node(trbt_node_t *node)
 	   predecessor instead.
 	   The predecessor is guaranteed to have at most one child
 	   node since its right arm must be NULL
-	   (It must be NULL since we are its sucessor and we are above
+	   (It must be NULL since we are its successor and we are above
 	    it in the tree)
 	 */
 	if (node->left != NULL && node->right != NULL) {

--- a/ccan/rfc822/rfc822.h
+++ b/ccan/rfc822/rfc822.h
@@ -78,7 +78,7 @@ struct rfc822_msg *rfc822_start(const void *ctx, const char *p, size_t len);
  * rfc822_free - free an rfc822 message
  * @msg: message to free
  *
- * Frees an rfc822_msg context, including all subsiduary data
+ * Frees an rfc822_msg context, including all subsidiary data
  * structures.
  */
 void rfc822_free(struct rfc822_msg *msg);

--- a/ccan/str/hex/_info
+++ b/ccan/str/hex/_info
@@ -5,7 +5,7 @@
 /**
  * str/hex - hex-to-string conversions and vice-versa
  *
- * This code contains simple routines for hexidecimal strings.
+ * This code contains simple routines for hexadecimal strings.
  *
  * License: CC0 (Public domain)
  * Author: Rusty Russell <rusty@rustcorp.com.au>

--- a/ccan/str/hex/hex.h
+++ b/ccan/str/hex/hex.h
@@ -7,7 +7,7 @@
 
 /**
  * hex_decode - Unpack a hex string.
- * @str: the hexidecimal string
+ * @str: the hexadecimal string
  * @slen: the length of @str
  * @buf: the buffer to write the data into
  * @bufsize: the length of @buf

--- a/ccan/strgrp/_info
+++ b/ccan/strgrp/_info
@@ -51,7 +51,7 @@
  * threshold. Two measurements are used as rejecting filters (i.e. a failure to
  * exceed the threshold prevents further measurements being made):
  *
- * 4a. Comparsion of string lengths: String lengths must be within given bounds
+ * 4a. Comparison of string lengths: String lengths must be within given bounds
  * to satisfy the user-supplied similarity constraint. A negative result avoids
  * invoking the O(m * n) behaviour of LCS at the cost of O(m + n) in the two
  * strlen() invocations.

--- a/ccan/tal/stack/_info
+++ b/ccan/tal/stack/_info
@@ -3,7 +3,7 @@
 #include <string.h>
 
 /**
- * tal/stack - stack of tal contextes (inspired by talloc_stack)
+ * tal/stack - stack of tal contexts (inspired by talloc_stack)
  *
  * Implement a stack of tal contexts. A new (empty) context is pushed on top
  * of the stack using tal_newframe and it is popped/freed using tal_free().

--- a/ccan/tal/stack/stack.h
+++ b/ccan/tal/stack/stack.h
@@ -9,7 +9,7 @@
  *
  * Allocates and push a new tal context on top of the stack.
  * The context must be freed using tal_free() which will also pop it
- * off the stack, which will also free all its nested contextes, if any.
+ * off the stack, which will also free all its nested contexts, if any.
  *
  * NOTE: this function is not threadsafe.
  *

--- a/ccan/tal/tal.c
+++ b/ccan/tal/tal.c
@@ -495,7 +495,7 @@ void *tal_steal_(const tal_t *new_parent, const tal_t *ctx)
 		old_parent = ignore_destroying_bit(t->parent_child)->parent;
 
                 if (unlikely(!add_child(newpar, t))) {
-			/* We can always add to old parent, becuase it has a
+			/* We can always add to old parent, because it has a
 			 * children property already. */
 			if (!add_child(old_parent, t))
 				abort();

--- a/ccan/talloc/talloc.c
+++ b/ccan/talloc/talloc.c
@@ -621,7 +621,7 @@ static inline int talloc_unreference(const void *context, const void *ptr)
 
 /*
   remove a specific parent context from a pointer. This is a more
-  controlled varient of talloc_free()
+  controlled variant of talloc_free()
 */
 int talloc_unlink(const void *context, void *ptr)
 {

--- a/ccan/tap/tap.3
+++ b/ccan/tap/tap.3
@@ -285,7 +285,7 @@ diag("Expected return code 0, got return code %d", rcode);
 .Xc
 .El
 .Pp
-For maximum compatability your test program should return a particular
+For maximum compatibility your test program should return a particular
 exit code.  This is calculated by
 .Fn exit_status
 so it is sufficient to always return from
@@ -303,7 +303,7 @@ directory in the source distribution contains numerous tests of
 functionality, written using
 .Nm .
 Examine them for examples of how to construct test suites.
-.Sh COMPATABILITY
+.Sh COMPATIBILITY
 .Nm
 strives to be compatible with the Perl Test::More and Test::Harness 
 modules.  The test suite verifies that

--- a/ccan/time/time.h
+++ b/ccan/time/time.h
@@ -42,7 +42,7 @@ struct timerel {
 };
 
 /**
- * struct timeabs - an absolue time.
+ * struct timeabs - an absolute time.
  * @ts: the actual timespec value.
  *
  * For example, Midnight UTC January 1st, 1970: ts.tv_sec = 0, ts.tv_nsec = 0

--- a/ccan/tlist/_info
+++ b/ccan/tlist/_info
@@ -6,7 +6,7 @@
  * tlist - typesafe double linked list routines
  *
  * The list header contains routines for manipulating double linked lists;
- * this extends it so you can create list head types which only accomodate
+ * this extends it so you can create list head types which only accommodate
  * a specific entry type.
  *
  * Example:

--- a/ccan/tlist/tlist.h
+++ b/ccan/tlist/tlist.h
@@ -34,7 +34,7 @@
 	}
 
 /**
- * TLIST_INIT - initalizer for an empty tlist
+ * TLIST_INIT - initializer for an empty tlist
  * @name: the name of the list.
  *
  * Explicit initializer for an empty list.

--- a/ccan/tlist2/_info
+++ b/ccan/tlist2/_info
@@ -6,7 +6,7 @@
  * tlist2 - typesafe double linked list routines, alternative form
  *
  * The list header contains routines for manipulating double linked lists;
- * this extends it so you can create list head types which only accomodate
+ * this extends it so you can create list head types which only accommodate
  * a specific entry type.
  *
  * Compared to 'tlist', this:

--- a/ccan/tlist2/tlist2.h
+++ b/ccan/tlist2/tlist2.h
@@ -31,7 +31,7 @@
 		TCON_CONTAINER(canary, etype, link))
 
 /**
- * TLIST2_INIT - initalizer for an empty tlist
+ * TLIST2_INIT - initializer for an empty tlist
  * @name: the name of the list.
  *
  * Explicit initializer for an empty list.

--- a/ccan/xstring/xstring.h
+++ b/ccan/xstring/xstring.h
@@ -131,7 +131,7 @@ int xstrAddSubs(xstring *x, ...);
  * @x: pointer to xstring
  * @src: string to append
  *
- * Run xstrAdd. Reterminate at inital length if truncation occurs.
+ * Run xstrAdd. Reterminate at initial length if truncation occurs.
  *
  * Return: x->truncated
  */
@@ -141,7 +141,7 @@ int xstrAddSubs(xstring *x, ...);
  * @x: pointer to xstring
  * @...: one or more strings followed by NULL
  *
- * Run xstrCat. Reterminate at inital length if truncation occurs.
+ * Run xstrCat. Reterminate at initial length if truncation occurs.
  *
  * Return: x->truncated
  */
@@ -152,7 +152,7 @@ int xstrAddSubs(xstring *x, ...);
  * @sep: separator string
  * @...: one or more strings followed by NULL
  *
- * Run xstrJoin. Reterminate at inital length if truncation occurs.
+ * Run xstrJoin. Reterminate at initial length if truncation occurs.
  *
  * Return: x->truncated
  */
@@ -163,7 +163,7 @@ int xstrAddSubs(xstring *x, ...);
  * @x: pointer to xstring
  * @...: one or more pairs of string and length followed by NULL
  *
- * Run xstrAddSubs. Reterminate at inital length if truncation occurs.
+ * Run xstrAddSubs. Reterminate at initial length if truncation occurs.
  *
  * Return: x->truncated
  */

--- a/tools/ccanlint/licenses.c
+++ b/tools/ccanlint/licenses.c
@@ -92,7 +92,7 @@ const struct license_info licenses[] = {
 	},
 };
 
-/* License compatibilty chart (simplified: we don't test that licenses between
+/* License compatibility chart (simplified: we don't test that licenses between
  * files are compatible). */
 #define O true
 #define X false
@@ -130,7 +130,7 @@ bool license_compatible[LICENSE_UNKNOWN+1][LICENSE_UNKNOWN] = {
 #undef O
 
 /* See GPLv2 and v2 (basically same wording) for interpreting versions:
- * the "any later version" means the recepient can choose. */
+ * the "any later version" means the recipient can choose. */
 enum license which_license(struct doc_section *d)
 {
 	if (!d)


### PR DESCRIPTION
Fixing typos is sometimes very hard. It's not so easy to visually review them. Recently, I discovered a very useful tool for it, [misspell](https://github.com/client9/misspell). 

This pull request fixes minor typos detected by [misspell](https://github.com/client9/misspell) except for the false positives. If you would like me to work on other files as well, let me know. 

## before

```
$ misspell .
ccan/antithread/examples/arabella.c:131:43: "trinagle" is a misspelling of "triangle"
ccan/asort/test/run.c:38:12: "psuedo" is a misspelling of "pseudo"
ccan/asort/test/run.c:55:1: "psuedo" is a misspelling of "pseudo"
ccan/asort/test/run.c:62:1: "psuedo" is a misspelling of "pseudo"
ccan/autodata/autodata.h:15:53: "preceed" is a misspelling of "precede"
ccan/bitops/bitops.h:18:23: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:29:23: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:49:21: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:50:3: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:61:21: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:62:3: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:82:22: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:83:3: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:94:22: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:95:3: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:114:23: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:125:23: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:136:23: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:147:23: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:158:23: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:168:23: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:178:23: "signficant" is a misspelling of "significant"
ccan/bitops/bitops.h:188:23: "signficant" is a misspelling of "significant"
ccan/coroutine/coroutine.c:20:24: "addres" is a misspelling of "address"
ccan/crypto/sha256/benchmarks/double-sha-bench.c:36:18: "initalize" is a misspelling of "initialize"
ccan/darray/test/testLits.h:112:750: "ADN" is a misspelling of "AND"
ccan/darray/test/testLits.h:113:744: "ADN" is a misspelling of "AND"
ccan/darray/test/testLits.h:114:749: "ADN" is a misspelling of "AND"
ccan/darray/test/testLits.h:120:750: "ADN" is a misspelling of "AND"
ccan/darray/test/lotsOfStrings.h:5:50: "ADN" is a misspelling of "AND"
ccan/darray/test/lotsOfStrings.h:108:753: "ADN" is a misspelling of "AND"
ccan/darray/test/lotsOfStrings.h:229:260: "ADN" is a misspelling of "AND"
ccan/darray/test/lotsOfStrings.h:592:1124: "ECT" is a misspelling of "ETC"
ccan/darray/test/lotsOfStrings.h:906:772: "ECT" is a misspelling of "ETC"
ccan/darray/test/lotsOfStrings.h:930:698: "ADN" is a misspelling of "AND"
ccan/hash/hash.c:284:7: "noticably" is a misspelling of "noticeably"
ccan/hash/hash.c:461:7: "noticably" is a misspelling of "noticeably"
ccan/intmap/intmap.h:289:16: "preceeding" is a misspelling of "preceding"
ccan/intmap/intmap.h:303:16: "preceeding" is a misspelling of "preceding"
ccan/iscsi/scsi-lowlevel.c:121:30: "calcualte" is a misspelling of "calculate"
ccan/iscsi/scsi-lowlevel.c:201:30: "calcualte" is a misspelling of "calculate"
ccan/iscsi/scsi-lowlevel.c:271:30: "calcualte" is a misspelling of "calculate"
ccan/iscsi/scsi-lowlevel.c:415:30: "calcualte" is a misspelling of "calculate"
ccan/list/list.h:711:38: "wich" is a misspelling of "which"
ccan/list/list.h:743:38: "wich" is a misspelling of "which"
ccan/list/list.h:755:38: "wich" is a misspelling of "which"
ccan/list/list.h:774:38: "wich" is a misspelling of "which"
ccan/rbtree/rbtree.c:451:38: "sucessor" is a misspelling of "successor"
ccan/rfc822/rfc822.h:81:46: "subsiduary" is a misspelling of "subsidiary"
ccan/str/hex/hex.h:10:13: "hexidecimal" is a misspelling of "hexadecimal"
ccan/str/hex/_info:8:42: "hexidecimal" is a misspelling of "hexadecimal"
ccan/strgrp/_info:54:7: "Comparsion" is a misspelling of "Comparison"
ccan/tal/stack/stack.h:12:54: "contextes" is a misspelling of "contexts"
ccan/tal/stack/_info:6:28: "contextes" is a misspelling of "contexts"
ccan/tal/tal.c:498:39: "becuase" is a misspelling of "because"
ccan/talloc/talloc.c:624:13: "varient" is a misspelling of "variant"
ccan/tap/tap.3:288:12: "compatability" is a misspelling of "compatibility"
ccan/tap/tap.3:306:4: "COMPATABILITY" is a misspelling of "COMPATIBILITY"
ccan/time/time.h:45:23: "absolue" is a misspelling of "absolute"
ccan/tlist/_info:9:64: "accomodate" is a misspelling of "accommodate"
ccan/tlist/tlist.h:37:16: "initalizer" is a misspelling of "initializer"
ccan/tlist2/_info:9:64: "accomodate" is a misspelling of "accommodate"
ccan/tlist2/tlist2.h:34:17: "initalizer" is a misspelling of "initializer"
ccan/xstring/xstring.h:134:31: "inital" is a misspelling of "initial"
ccan/xstring/xstring.h:144:31: "inital" is a misspelling of "initial"
ccan/xstring/xstring.h:155:32: "inital" is a misspelling of "initial"
ccan/xstring/xstring.h:166:35: "inital" is a misspelling of "initial"
junkcode/iasoule32@gmail.com-polynomial/_info.c:6:68: "derivate" is a misspelling of "derivative"
junkcode/iasoule32@gmail.com-polynomial/polynomial_adt.h:3:26: "derivate" is a misspelling of "derivative"
junkcode/iasoule32@gmail.com-polynomial/test/run.c:84:16: "derivitive" is a misspelling of "derivative"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.txt:603:25: "heirarchy" is a misspelling of "hierarchy"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.txt:738:53: "changable" is a misspelling of "changeable"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.txt:789:15: "preceeding" is a misspelling of "preceding"
junkcode/rusty@rustcorp.com.au-ntdb/ntdb.c:331:21: "changable" is a misspelling of "changeable"
junkcode/rusty@rustcorp.com.au-ntdb/ntdb.c:376:15: "changable" is a misspelling of "changeable"
junkcode/rusty@rustcorp.com.au-ntdb/ntdb.c:420:15: "changable" is a misspelling of "changeable"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.lyx:1456:25: "heirarchy" is a misspelling of "hierarchy"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.lyx:1698:36: "changable" is a misspelling of "changeable"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.lyx:1798:12: "preceeding" is a misspelling of "preceding"
junkcode/rusty@rustcorp.com.au-ntdb/test/api-open-multiple-times.c:72:5: "Transaciton" is a misspelling of "Transactions"
junkcode/swehack@gmail.com-snifstat/snifstat.c:61:20: "filterd" is a misspelling of "filtered"
junkcode/swehack@gmail.com-snifstat/snifstat.c:133:24: "filterd" is a misspelling of "filtered"
junkcode/swehack@gmail.com-snifstat/snifstat.c:138:26: "filterd" is a misspelling of "filtered"
tools/ccanlint/licenses.c:95:11: "compatibilty" is a misspelling of "compatibility"
tools/ccanlint/licenses.c:133:37: "recepient" is a misspelling of "recipient"
```

## after

```
$ misspell .
ccan/darray/test/testLits.h:112:750: "ADN" is a misspelling of "AND"
ccan/darray/test/testLits.h:113:744: "ADN" is a misspelling of "AND"
ccan/darray/test/testLits.h:114:749: "ADN" is a misspelling of "AND"
ccan/darray/test/testLits.h:120:750: "ADN" is a misspelling of "AND"
ccan/darray/test/lotsOfStrings.h:5:50: "ADN" is a misspelling of "AND"
ccan/darray/test/lotsOfStrings.h:108:753: "ADN" is a misspelling of "AND"
ccan/darray/test/lotsOfStrings.h:229:260: "ADN" is a misspelling of "AND"
ccan/darray/test/lotsOfStrings.h:592:1124: "ECT" is a misspelling of "ETC"
ccan/darray/test/lotsOfStrings.h:906:772: "ECT" is a misspelling of "ETC"
ccan/darray/test/lotsOfStrings.h:930:698: "ADN" is a misspelling of "AND"
junkcode/iasoule32@gmail.com-polynomial/_info.c:6:68: "derivate" is a misspelling of "derivative"
junkcode/iasoule32@gmail.com-polynomial/test/run.c:84:16: "derivitive" is a misspelling of "derivative"
junkcode/iasoule32@gmail.com-polynomial/polynomial_adt.h:3:26: "derivate" is a misspelling of "derivative"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.txt:603:25: "heirarchy" is a misspelling of "hierarchy"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.txt:738:53: "changable" is a misspelling of "changeable"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.txt:789:15: "preceeding" is a misspelling of "preceding"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.lyx:1456:25: "heirarchy" is a misspelling of "hierarchy"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.lyx:1698:36: "changable" is a misspelling of "changeable"
junkcode/rusty@rustcorp.com.au-ntdb/doc/design.lyx:1798:12: "preceeding" is a misspelling of "preceding"
junkcode/rusty@rustcorp.com.au-ntdb/ntdb.c:331:21: "changable" is a misspelling of "changeable"
junkcode/rusty@rustcorp.com.au-ntdb/ntdb.c:376:15: "changable" is a misspelling of "changeable"
junkcode/rusty@rustcorp.com.au-ntdb/ntdb.c:420:15: "changable" is a misspelling of "changeable"
junkcode/rusty@rustcorp.com.au-ntdb/test/api-open-multiple-times.c:72:5: "Transaciton" is a misspelling of "Transactions"
junkcode/swehack@gmail.com-snifstat/snifstat.c:61:20: "filterd" is a misspelling of "filtered"
junkcode/swehack@gmail.com-snifstat/snifstat.c:133:24: "filterd" is a misspelling of "filtered"
junkcode/swehack@gmail.com-snifstat/snifstat.c:138:26: "filterd" is a misspelling of "filtered"
```

see also: https://github.com/ruby/ruby/pull/1925