### PR TITLE
Fix read_all() and write_all() to always set errno on failure

### DIFF
--- a/ccan/read_write_all/read_write_all.c
+++ b/ccan/read_write_all/read_write_all.c
@@ -26,12 +26,20 @@ bool read_all(int fd, void *data, size_t size)
 		ssize_t done;
 
 		done = read(fd, data, size);
-		if (done < 0 && errno == EINTR)
-			continue;
-		if (done <= 0)
+
+		switch (done) {
+		case -1:
+			if (errno == EINTR) {
+				continue;
+			}
 			return false;
-		data = (char *)data + done;
-		size -= done;
+		case 0:
+			errno = EBADMSG;
+			return false;
+		default:
+			data = (char *)data + done;
+			size -= done;
+		}
 	}
 
 	return true;

--- a/ccan/read_write_all/read_write_all.c
+++ b/ccan/read_write_all/read_write_all.c
@@ -9,10 +9,12 @@ bool write_all(int fd, const void *data, size_t size)
 		ssize_t done;
 
 		done = write(fd, data, size);
-		if (done < 0 && errno == EINTR)
-			continue;
-		if (done <= 0)
+		if (done < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
 			return false;
+		}
 		data = (const char *)data + done;
 		size -= done;
 	}

--- a/ccan/read_write_all/read_write_all.h
+++ b/ccan/read_write_all/read_write_all.h
@@ -4,6 +4,12 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+/**
+ * Write `size` bytes from `data` to the file descriptor `fd`, retrying on
+ * transient errors.
+ * If the data cannot be fully written, then false is returned and errno is set
+ * to indicate the error.
+ */
 bool write_all(int fd, const void *data, size_t size);
 
 /**

--- a/ccan/read_write_all/read_write_all.h
+++ b/ccan/read_write_all/read_write_all.h
@@ -5,6 +5,14 @@
 #include <stdbool.h>
 
 bool write_all(int fd, const void *data, size_t size);
+
+/**
+ * Read `size` bytes from the file descriptor `fd` into `data`, retrying on
+ * transient errors.
+ * If `size` bytes cannot be read then false is returned and errno is set
+ * to indicate the error, in which case the contents of `data` is undefined.
+ * If EOF occurs before `size` bytes were read, then errno is set to EBADMSG.
+ */
 bool read_all(int fd, void *data, size_t size);
 
 #endif /* _CCAN_READ_WRITE_H */


### PR DESCRIPTION
Make sure `errno` is always set if `false` is to be returned. Also retry if `write(2)` returns 0.