### PR TITLE
configurator: always true branch

### DIFF
--- a/tools/configurator/configurator.c
+++ b/tools/configurator/configurator.c
@@ -762,9 +762,7 @@ static bool run_test(const char *cmd, const char *wrapper, struct test *test)
 			strcpy(cmd, wrapper);
 			strcat(cmd, " ." DIR_SEP OUTPUT_FILE);
 			output = run(cmd, &status);
-			if (wrapper) {
-				free(cmd);
-			}
+			free(cmd);
 			if (!strstr(test->style, "EXECUTE") && status != 0)
 				c12r_errx(EXIT_BAD_TEST,
 					  "Test for %s failed with %i:\n%s",


### PR DESCRIPTION
removes a branch that always was true.