### PR TITLE
docs: fix simple typo, unchaged -> unchanged

### DIFF
--- a/ccan/objset/objset.h
+++ b/ccan/objset/objset.h
@@ -132,7 +132,7 @@ static inline bool objset_empty_(const struct objset_h *set)
 /**
  * objset_iter - iterator reference.
  *
- * This is valid for a particular set as long as the contents remain unchaged,
+ * This is valid for a particular set as long as the contents remain unchanged,
  * otherwise the effect is undefined.
  */
 struct objset_iter {


### PR DESCRIPTION
There is a small typo in ccan/objset/objset.h.

Should read `unchanged` rather than `unchaged`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md