### PR TITLE
Fix potential null pointer dereferencing in ttxml

### DIFF
--- a/ccan/ttxml/ttxml.c
+++ b/ccan/ttxml/ttxml.c
@@ -393,6 +393,7 @@ xml_load_fail_malloc_buf:
 XmlNode * xml_find(XmlNode *xml, const char *name)
 {
 	XmlNode * ret;
+	if(!xml) return NULL;
 	if(xml->name)if(!strcmp(xml->name, name))return xml;
 	if(xml->child)
 	{


### PR DESCRIPTION
Add a check if a null pointer is passed to the function xml_find.