### PR TITLE
GraphQL: Add convenience fields to the syntax tree

### DIFF
--- a/ccan/graphql/_info
+++ b/ccan/graphql/_info
@@ -21,14 +21,14 @@
  *		struct graphql_executable_document *output_document;
  *	
  *		const char *errmsg = graphql_lexparse(
- *			input_string,
  *			NULL, // tal context
+ *			input_string,
  *			&output_tokens, // variable to receive tokens
  *			&output_document); // variable to receive AST
  *	
  *		if (errmsg) {
  *			struct graphql_token *last_token;
- *			last_token = list_tail(output_tokens, struct graphql_token, list);
+ *			last_token = list_tail(output_tokens, struct graphql_token, node);
  *			printf("Line %d, col %d: %s",
  *				last_token->source_line,
  *				last_token->source_column + last_token->source_len,

--- a/ccan/graphql/graphql.c
+++ b/ccan/graphql/graphql.c
@@ -30,10 +30,10 @@
 
 /* Parser shorthands
  *
- * These (perhaps unusual) shorthands are used so that the parser functions can be
- * written in a format that almost exactly matches the specification.
+ * These shorthands are motivated by the parser functions, so they can be
+ * written in a format that corresponds closely to the specification.
  */
-#define RET void *
+#define RET static void *
 #define PARAMS struct list_head *tokens, struct list_head *used, const char **err
 #define ARGS tokens, used, err
 #define INIT(type) \
@@ -58,115 +58,12 @@
 #define MSG(msg) if (*err) *err = msg;
 
 
-// Parser functions
-
-RET parse_document(PARAMS);
-RET parse_definition(PARAMS);
-RET parse_executable_document(PARAMS);
-RET parse_executable_definition(PARAMS);
-RET parse_operation_definition(PARAMS);
-RET parse_operation_type(PARAMS);
-RET parse_selection_set(PARAMS);
-RET parse_selection(PARAMS);
-RET parse_field(PARAMS);
-RET parse_arguments(PARAMS);
-RET parse_argument(PARAMS);
-RET parse_alias(PARAMS);
-RET parse_fragment_spread(PARAMS);
-RET parse_fragment_definition(PARAMS);
-RET parse_fragment_name(PARAMS);
-RET parse_type_condition(PARAMS);
-RET parse_inline_fragment(PARAMS);
-RET parse_value(PARAMS);
-RET parse_int_value(PARAMS);
-RET parse_negative_sign(PARAMS);
-RET parse_non_zero_digit(PARAMS);
-RET parse_float_value(PARAMS);
-RET parse_boolean_value(PARAMS);
-RET parse_string_value(PARAMS);
-RET parse_string_character(PARAMS);
-RET parse_escaped_unicode(PARAMS);
-RET parse_escaped_character(PARAMS);
-RET parse_block_string_character(PARAMS);
-RET parse_null_value(PARAMS);
-RET parse_enum_value(PARAMS);
-RET parse_list_value(PARAMS);
-RET parse_object_value(PARAMS);
-RET parse_object_field(PARAMS);
-RET parse_variable(PARAMS);
-RET parse_variable_definitions(PARAMS);
-RET parse_variable_definition(PARAMS);
-RET parse_default_value(PARAMS);
-RET parse_type(PARAMS);
-RET parse_named_type(PARAMS);
-RET parse_list_type(PARAMS);
-RET parse_non_null_type(PARAMS);
-RET parse_non_null_type_1(PARAMS);
-RET parse_non_null_type_2(PARAMS);
-RET parse_directives(PARAMS);
-RET parse_directive(PARAMS);
-RET parse_type_system_document(PARAMS);
-RET parse_type_system_definition(PARAMS);
-RET parse_type_system_extension_document(PARAMS);
-RET parse_type_system_definition_or_extension(PARAMS);
-RET parse_type_system_extension(PARAMS);
-RET parse_description(PARAMS);
-RET parse_schema_definition(PARAMS);
-RET parse_root_operation_type_definition(PARAMS);
-RET parse_schema_extension(PARAMS);
-RET parse_type_definition(PARAMS);
-RET parse_type_extension(PARAMS);
-RET parse_scalar_type_definition(PARAMS);
-RET parse_scalar_type_extension(PARAMS);
-RET parse_object_type_definition(PARAMS);
-RET parse_implements_interfaces(PARAMS);
-RET parse_fields_definition(PARAMS);
-RET parse_field_definition(PARAMS);
-RET parse_arguments_definition(PARAMS);
-RET parse_input_value_definition(PARAMS);
-RET parse_object_type_extension(PARAMS);
-RET parse_interface_type_definition(PARAMS);
-RET parse_interface_type_extension(PARAMS);
-RET parse_union_type_definition(PARAMS);
-RET parse_union_member_types(PARAMS);
-RET parse_union_type_extension(PARAMS);
-RET parse_enum_type_definition(PARAMS);
-RET parse_enum_values_definition(PARAMS);
-RET parse_enum_value_definition(PARAMS);
-RET parse_enum_type_extension(PARAMS);
-RET parse_input_object_type_definition(PARAMS);
-RET parse_input_fields_definition(PARAMS);
-RET parse_directive_definition(PARAMS);
-RET parse_directive_locations(PARAMS);
-RET parse_directive_location(PARAMS);
-RET parse_executable_directive_location(PARAMS);
-RET parse_type_system_directive_location(PARAMS);
-
-RET parse_keyword(PARAMS, const char *keyword, const char *errmsg);
-RET parse_punct(PARAMS, int punct);
-RET parse_name(PARAMS);
-RET parse_int(PARAMS);
-RET parse_float(PARAMS);
-RET parse_string(PARAMS);
-
-
-// Convert input string into AST.
-const char *graphql_lexparse(const tal_t *ctx, const char *input, struct list_head **tokens, struct graphql_executable_document **doc) {
-	const char *err = graphql_lex(ctx, input, tokens);
-	if (!err)
-		err = graphql_parse(*tokens, doc);
-	return err;
-}
-
-// Convert lexed tokens into AST.
-const char *graphql_parse(struct list_head *tokens, struct graphql_executable_document **doc) {
-	struct list_head used = LIST_HEAD_INIT(used);
-	const char *err = NULL;
-	*doc = parse_executable_document(tokens, &used, &err);
-	return err;
-}
-
-/* The following parser functions follow special rules:
+/* The following parser functions are written in a way that corresponds to the
+ * grammar defined in the GraphQL specification. The code is not intended to
+ * look like normal C code; it's designed for parsing clarity rather than C
+ * style. Think of it as something generated rather than something to read.
+ * For that reason, the functions follow special rules:
+ *
  *	- The declaration is standardized with RET and PARAMS
  *	- The "err" argument is assumed to be NULL upon entrance
  *	- The "err" argument is set on failure
@@ -174,381 +71,6 @@ const char *graphql_parse(struct list_head *tokens, struct graphql_executable_do
  *	- INIT and EXIT macros are used
  *	- Macros such as REQ and OPT facilitate readability and conciseness
  */
-
-RET parse_document(PARAMS) {
-	INIT(document);
-	obj->first_def = parse_definition(ARGS); REQ
-	struct graphql_definition *p = obj->first_def;
-	do {
-		p->next_def = parse_definition(ARGS);
-		p = p->next_def;
-	} WHILE_OPT;
-	EXIT;
-}
-
-RET parse_definition(PARAMS) {
-	INIT(definition);
-	obj->executable_def = parse_executable_definition(ARGS);
-/*	OR
-	obj->type_system_def = parse_type_system_definition_or_extension(ARGS);
-	// NOTE: Optional type system is not (yet) implemented.
-*/
-	EXIT;
-}
-
-RET parse_executable_document(PARAMS) {
-	INIT(executable_document);
-	obj->first_def = parse_executable_definition(ARGS); REQ
-	struct graphql_executable_definition *p = obj->first_def;
-	do {
-		p->next_def = parse_executable_definition(ARGS);
-		p = p->next_def;
-	} WHILE_OPT;
-	EXIT;
-}
-
-RET parse_executable_definition(PARAMS) {
-	INIT(executable_definition);
-	obj->op_def = parse_operation_definition(ARGS); MSG("invalid operation or fragment definition"); OR
-	obj->frag_def = parse_fragment_definition(ARGS); MSG("invalid operation or fragment definition"); 
-	EXIT;
-}
-
-RET parse_operation_definition(PARAMS) {
-	INIT(operation_definition);
-	obj->op_type = parse_operation_type(ARGS);
-	if (!*err) {
-		obj->op_name = parse_name(ARGS); OPT
-		obj->vars = parse_variable_definitions(ARGS); OPT
-		obj->directives = parse_directives(ARGS); OPT
-	} else
-		*err = NULL;
-	obj->sel_set = parse_selection_set(ARGS);
-	if (*err) ROLLBACK(ARGS);
-	EXIT;
-}
-
-RET parse_operation_type(PARAMS) {
-	INIT(operation_type);
-	const char *errmsg = "expected: query, mutation, or subscription";
-	obj->op_type = parse_keyword(ARGS, "query", errmsg); OR
-	obj->op_type = parse_keyword(ARGS, "mutation", errmsg); OR
-	obj->op_type = parse_keyword(ARGS, "subscription", errmsg);
-	EXIT;
-}
-
-RET parse_selection_set(PARAMS) {
-	INIT(selection_set);
-	parse_punct(ARGS, '{'); REQ;
-	obj->first = parse_selection(ARGS); REQ;
-	struct graphql_selection *p = obj->first;
-	parse_punct(ARGS, '}');
-	while (*err) {
-		*err = NULL;
-		p->next = parse_selection(ARGS); MSG("expected: selection or '}'"); REQ;
-		p = p->next;
-		parse_punct(ARGS, '}');
-	}
-	EXIT;
-}
-
-RET parse_selection(PARAMS) {
-	INIT(selection);
-	obj->field = parse_field(ARGS); OR
-	obj->frag_spread = parse_fragment_spread(ARGS); OR
-	obj->inline_frag = parse_inline_fragment(ARGS);
-	MSG("expected: field, fragment spread, or inline fragment");
-	EXIT;
-}
-
-RET parse_field(PARAMS) {
-	INIT(field);
-	obj->alias = parse_alias(ARGS); OPT
-	obj->name = parse_name(ARGS); REQ
-	obj->args = parse_arguments(ARGS); OPT
-	obj->directives = parse_directives(ARGS); OPT
-	obj->sel_set = parse_selection_set(ARGS); OPT
-	EXIT;
-}
-
-RET parse_arguments(PARAMS) {
-	INIT(arguments);
-	parse_punct(ARGS, '('); REQ
-	obj->first = parse_argument(ARGS); REQ
-	struct graphql_argument *p = obj->first;
-	parse_punct(ARGS, ')');
-	while (*err) {
-		*err = NULL;
-		p->next = parse_argument(ARGS); MSG("expected: argument or ')'"); REQ;
-		p = p->next;
-		parse_punct(ARGS, ')');
-	}
-	EXIT;
-}
-
-RET parse_argument(PARAMS) {
-	INIT(argument);
-	obj->name = parse_name(ARGS); REQ
-	parse_punct(ARGS, ':'); REQ
-	obj->val = parse_value(ARGS); REQ
-	EXIT;
-}
-
-RET parse_alias(PARAMS) {
-	INIT(alias);
-	obj->name = parse_name(ARGS); REQ
-	parse_punct(ARGS, ':'); REQ
-	EXIT;
-}
-
-RET parse_fragment_spread(PARAMS) {
-	INIT(fragment_spread);
-	parse_punct(ARGS, 0x2026); REQ // ...
-	obj->name = parse_fragment_name(ARGS); REQ
-	obj->directives = parse_directives(ARGS); OPT
-	EXIT;
-}
-
-RET parse_fragment_definition(PARAMS) {
-	INIT(fragment_definition);
-	parse_keyword(ARGS, "fragment", "fragment expected"); REQ
-	obj->name = parse_fragment_name(ARGS); REQ
-	obj->type_cond = parse_type_condition(ARGS); REQ
-	obj->directives = parse_directives(ARGS); OPT
-	obj->sel_set = parse_selection_set(ARGS); REQ
-	EXIT;
-}
-
-RET parse_fragment_name(PARAMS) {
-	INIT(fragment_name);
-	obj->name = parse_name(ARGS); REQ
-	struct graphql_token *tok = list_top(used, struct graphql_token, node);
-	if (streq(tok->token_string, "on")) {
-		*err = "invalid fragment name";
-		ROLLBACK(ARGS);
-	}
-	EXIT;
-}
-
-RET parse_type_condition(PARAMS) {
-	INIT(type_condition);
-	parse_keyword(ARGS, "on", "expected: 'on'"); REQ
-	obj->named_type = parse_named_type(ARGS); REQ
-	EXIT;
-}
-
-RET parse_inline_fragment(PARAMS) {
-	INIT(inline_fragment);
-	parse_punct(ARGS, 0x2026); REQ // ...
-	obj->type_cond = parse_type_condition(ARGS); OPT
-	obj->directives = parse_directives(ARGS); OPT
-	obj->sel_set = parse_selection_set(ARGS); REQ
-	EXIT;
-}
-
-RET parse_value(PARAMS) {
-	INIT(value);
-	obj->var = parse_variable(ARGS); // FIXME: if not const
-	OR
-	obj->int_val = parse_int_value(ARGS); OR
-	obj->float_val = parse_float_value(ARGS); OR
-	obj->str_val = parse_string_value(ARGS); OR
-	obj->bool_val = parse_boolean_value(ARGS); OR
-	obj->null_val = parse_null_value(ARGS); OR
-	obj->enum_val = parse_enum_value(ARGS); OR
-	obj->list_val = parse_list_value(ARGS); OR
-	obj->obj_val = parse_object_value(ARGS);
-	EXIT;
-}
-
-RET parse_int_value(PARAMS) {
-	INIT(int_value);
-	obj->val = parse_int(ARGS);
-	EXIT;
-}
-
-RET parse_float_value(PARAMS) {
-	INIT(float_value);
-	obj->val = parse_float(ARGS);
-	EXIT;
-}
-
-RET parse_boolean_value(PARAMS) {
-	INIT(boolean_value);
-	obj->val = parse_keyword(ARGS, "true", "invalid boolean value"); OR
-	obj->val = parse_keyword(ARGS, "false", "invalid boolean value");
-	EXIT;
-}
-
-RET parse_string_value(PARAMS) {
-	INIT(string_value);
-	obj->val = parse_string(ARGS);
-	EXIT;
-}
-
-RET parse_null_value(PARAMS) {
-	INIT(null_value);
-	obj->val = parse_keyword(ARGS, "null", "null expected");
-	EXIT;
-}
-
-RET parse_enum_value(PARAMS) {
-	INIT(enum_value);
-	obj->val = parse_name(ARGS); REQ
-	struct graphql_token *tok = list_top(used, struct graphql_token, node);
-	if (streq(tok->token_string, "true")
-	 || streq(tok->token_string, "false")
-	 || streq(tok->token_string, "null")) {
-		*err = "enum value cannot be true, false, or null";
-		ROLLBACK(ARGS);
-	}
-	EXIT;
-}
-
-RET parse_list_value(PARAMS) {
-	INIT(list_value);
-	parse_punct(ARGS, '['); REQ
-	parse_punct(ARGS, ']');
-	while (*err) {
-		*err = NULL;
-		parse_value(ARGS); MSG("expected: value or ']'"); REQ
-		parse_punct(ARGS, ']');
-	}
-	EXIT;
-}
-
-RET parse_object_value(PARAMS) {
-	INIT(object_value);
-	parse_punct(ARGS, '{'); REQ
-	parse_punct(ARGS, '}');
-	struct graphql_object_field *p = NULL;
-	while (*err) {
-		*err = NULL;
-		if (!p) {
-			obj->first = p = parse_object_field(ARGS); MSG("expected: object field or '}'"); REQ
-		} else {
-			p->next = parse_object_field(ARGS); MSG("expected: object field or '}'"); REQ
-			p = p->next;
-		}
-		parse_punct(ARGS, '}');
-	}
-	EXIT;
-}
-
-RET parse_object_field(PARAMS) {
-	INIT(object_field);
-	obj->name = parse_name(ARGS); REQ
-	parse_punct(ARGS, ':'); REQ
-	obj->val = parse_value(ARGS); REQ
-	EXIT;
-}
-
-RET parse_variable(PARAMS) {
-	INIT(variable);
-	parse_punct(ARGS, '$'); REQ
-	obj->name = parse_name(ARGS); REQ
-	EXIT;
-}
-
-RET parse_variable_definitions(PARAMS) {
-	INIT(variable_definitions);
-	parse_punct(ARGS, '('); REQ
-	obj->first = parse_variable_definition(ARGS); REQ
-	struct graphql_variable_definition *p = obj->first;
-	parse_punct(ARGS, ')');
-	while (*err) {
-		*err = NULL;
-		p->next = parse_variable_definition(ARGS); MSG("expected: variable definition or ')'"); REQ
-		p = p->next;
-		parse_punct(ARGS, ')');
-	}
-	EXIT;
-}
-
-RET parse_variable_definition(PARAMS) {
-	INIT(variable_definition);
-	obj->var = parse_variable(ARGS); REQ
-	parse_punct(ARGS, ':'); REQ
-	obj->type = parse_type(ARGS); REQ
-	obj->default_val = parse_default_value(ARGS); OPT
-	obj->directives = parse_directives(ARGS); OPT
-	EXIT;
-}
-
-RET parse_default_value(PARAMS) {
-	INIT(default_value);
-	parse_punct(ARGS, '='); REQ
-	obj->val = parse_value(ARGS); REQ
-	EXIT;
-}
-
-RET parse_type(PARAMS) {
-	INIT(type);
-	obj->named = parse_named_type(ARGS);
-/*
-	OR
-	obj->list = parse_list_type(ARGS); OR
-	obj->non_null = parse_non_null_type(ARGS);
-*/
-	EXIT;
-}
-
-RET parse_named_type(PARAMS) {
-	INIT(named_type);
-	obj->name = parse_name(ARGS);
-	EXIT;
-}
-
-/*
-RET parse_list_type(PARAMS) {
-	INIT(list_type);
-	parse_punct(ARGS, '['); REQ
-	parse_type(ARGS); REQ
-	parse_punct(ARGS, ']'); REQ
-	EXIT;
-}
-
-RET parse_non_null_type(PARAMS) {
-	INIT(non_null_type);
-	parse_non_null_type_1(ARGS); OR
-	parse_non_null_type_2(ARGS);
-	EXIT;
-}
-
-RET parse_non_null_type_1(PARAMS) {
-	INIT(non_null_type);
-	parse_named_type(ARGS); REQ;
-	parse_punct(ARGS, '!'); REQ;
-	EXIT;
-}
-
-RET parse_non_null_type_2(PARAMS) {
-	INIT(non_null_type);
-	parse_list_type(ARGS); REQ;
-	parse_punct(ARGS, '!'); REQ;
-	EXIT;
-}
-*/
-
-RET parse_directives(PARAMS) {
-	INIT(directives);
-	obj->first = parse_directive(ARGS); REQ
-	struct graphql_directive *p = obj->first;
-	do {
-		p->next = parse_directive(ARGS);
-		p = p->next;
-	} WHILE_OPT;
-	EXIT;
-}
-
-RET parse_directive(PARAMS) {
-	INIT(directive);
-	parse_punct(ARGS, '@'); REQ
-	obj->name = parse_name(ARGS); REQ
-	obj->args = parse_arguments(ARGS); OPT
-	EXIT;
-}
-
 
 /* The following functions construct the "leaves" of the abstract syntax tree. */
 
@@ -569,7 +91,7 @@ RET parse_punct(PARAMS, int punct) {
 	static char punctbuf[16];
 	struct graphql_token *tok = list_top(tokens, struct graphql_token, node);
 	if (!tok || tok->token_type != punct) {
-		if (punct == 0x2026)
+		if (punct == PUNCT_SPREAD)
 			sprintf(punctbuf, "expected: '...'");
 		else
 			sprintf(punctbuf, "expected: '%c'", punct);
@@ -615,6 +137,386 @@ RET parse_string(PARAMS) {
 	return tok;
 }
 
+// The following functions create the branches of the AST.
+
+/*
+RET parse_non_null_type_2(PARAMS) {
+	INIT(non_null_type);
+	parse_list_type(ARGS); REQ;
+	parse_punct(ARGS, '!'); REQ;
+	EXIT;
+}
+
+RET parse_non_null_type_1(PARAMS) {
+	INIT(non_null_type);
+	parse_named_type(ARGS); REQ;
+	parse_punct(ARGS, '!'); REQ;
+	EXIT;
+}
+
+RET parse_non_null_type(PARAMS) {
+	INIT(non_null_type);
+	parse_non_null_type_1(ARGS); OR
+	parse_non_null_type_2(ARGS);
+	EXIT;
+}
+
+RET parse_list_type(PARAMS) {
+	INIT(list_type);
+	parse_punct(ARGS, '['); REQ
+	parse_type(ARGS); REQ
+	parse_punct(ARGS, ']'); REQ
+	EXIT;
+}
+*/
+
+RET parse_named_type(PARAMS) {
+	INIT(named_type);
+	obj->name = parse_name(ARGS);
+	EXIT;
+}
+
+RET parse_type(PARAMS) {
+	INIT(type);
+	obj->named = parse_named_type(ARGS);
+/*
+	OR
+	obj->list = parse_list_type(ARGS); OR
+	obj->non_null = parse_non_null_type(ARGS);
+*/
+	EXIT;
+}
+
+RET parse_variable(PARAMS) {
+	INIT(variable);
+	parse_punct(ARGS, '$'); REQ
+	obj->name = parse_name(ARGS); REQ
+	EXIT;
+}
+
+RET parse_value(PARAMS);
+
+RET parse_list_value(PARAMS) {
+	INIT(list_value);
+	parse_punct(ARGS, '['); REQ
+	parse_punct(ARGS, ']');
+	while (*err) {
+		*err = NULL;
+		parse_value(ARGS); MSG("expected: value or ']'"); REQ
+		parse_punct(ARGS, ']');
+	}
+	EXIT;
+}
+
+RET parse_enum_value(PARAMS) {
+	INIT(enum_value);
+	obj->val = parse_name(ARGS); REQ
+	struct graphql_token *tok = list_top(used, struct graphql_token, node);
+	if (streq(tok->token_string, "true")
+	 || streq(tok->token_string, "false")
+	 || streq(tok->token_string, "null")) {
+		*err = "enum value cannot be true, false, or null";
+		ROLLBACK(ARGS);
+	}
+	EXIT;
+}
+
+RET parse_null_value(PARAMS) {
+	INIT(null_value);
+	obj->val = parse_keyword(ARGS, "null", "null expected");
+	EXIT;
+}
+
+RET parse_string_value(PARAMS) {
+	INIT(string_value);
+	obj->val = parse_string(ARGS);
+	EXIT;
+}
+
+RET parse_boolean_value(PARAMS) {
+	INIT(boolean_value);
+	obj->val = parse_keyword(ARGS, "true", "invalid boolean value"); OR
+	obj->val = parse_keyword(ARGS, "false", "invalid boolean value");
+	EXIT;
+}
+
+RET parse_float_value(PARAMS) {
+	INIT(float_value);
+	obj->val = parse_float(ARGS);
+	EXIT;
+}
+
+RET parse_int_value(PARAMS) {
+	INIT(int_value);
+	obj->val = parse_int(ARGS);
+	EXIT;
+}
+
+RET parse_object_field(PARAMS) {
+	INIT(object_field);
+	obj->name = parse_name(ARGS); REQ
+	parse_punct(ARGS, ':'); REQ
+	obj->val = parse_value(ARGS); REQ
+	EXIT;
+}
+
+RET parse_object_value(PARAMS) {
+	INIT(object_value);
+	parse_punct(ARGS, '{'); REQ
+	parse_punct(ARGS, '}');
+	struct graphql_object_field *p = NULL;
+	while (*err) {
+		*err = NULL;
+		if (!p) {
+			obj->first = p = parse_object_field(ARGS); MSG("expected: object field or '}'"); REQ
+		} else {
+			p->next = parse_object_field(ARGS); MSG("expected: object field or '}'"); REQ
+			p = p->next;
+		}
+		parse_punct(ARGS, '}');
+	}
+	EXIT;
+}
+
+RET parse_default_value(PARAMS) {
+	INIT(default_value);
+	parse_punct(ARGS, '='); REQ
+	obj->val = parse_value(ARGS); REQ
+	EXIT;
+}
+
+RET parse_value(PARAMS) {
+	INIT(value);
+	obj->var = parse_variable(ARGS); // FIXME: if not const
+	OR
+	obj->int_val = parse_int_value(ARGS); OR
+	obj->float_val = parse_float_value(ARGS); OR
+	obj->str_val = parse_string_value(ARGS); OR
+	obj->bool_val = parse_boolean_value(ARGS); OR
+	obj->null_val = parse_null_value(ARGS); OR
+	obj->enum_val = parse_enum_value(ARGS); OR
+	obj->list_val = parse_list_value(ARGS); OR
+	obj->obj_val = parse_object_value(ARGS);
+	EXIT;
+}
+
+RET parse_type_condition(PARAMS) {
+	INIT(type_condition);
+	parse_keyword(ARGS, "on", "expected: 'on'"); REQ
+	obj->named_type = parse_named_type(ARGS); REQ
+	EXIT;
+}
+
+RET parse_fragment_name(PARAMS) {
+	INIT(fragment_name);
+	obj->name = parse_name(ARGS); REQ
+	struct graphql_token *tok = list_top(used, struct graphql_token, node);
+	if (streq(tok->token_string, "on")) {
+		*err = "invalid fragment name";
+		ROLLBACK(ARGS);
+	}
+	EXIT;
+}
+
+RET parse_alias(PARAMS) {
+	INIT(alias);
+	obj->name = parse_name(ARGS); REQ
+	parse_punct(ARGS, ':'); REQ
+	EXIT;
+}
+
+RET parse_argument(PARAMS) {
+	INIT(argument);
+	obj->name = parse_name(ARGS); REQ
+	parse_punct(ARGS, ':'); REQ
+	obj->val = parse_value(ARGS); REQ
+	EXIT;
+}
+
+RET parse_arguments(PARAMS) {
+	INIT(arguments);
+	parse_punct(ARGS, '('); REQ
+	obj->first = parse_argument(ARGS); REQ
+	struct graphql_argument *p = obj->first;
+	parse_punct(ARGS, ')');
+	while (*err) {
+		*err = NULL;
+		p->next = parse_argument(ARGS); MSG("expected: argument or ')'"); REQ;
+		p = p->next;
+		parse_punct(ARGS, ')');
+	}
+	EXIT;
+}
+
+RET parse_directive(PARAMS) {
+	INIT(directive);
+	parse_punct(ARGS, '@'); REQ
+	obj->name = parse_name(ARGS); REQ
+	obj->args = parse_arguments(ARGS); OPT
+	EXIT;
+}
+
+RET parse_directives(PARAMS) {
+	INIT(directives);
+	obj->first = parse_directive(ARGS); REQ
+	struct graphql_directive *p = obj->first;
+	do {
+		p->next = parse_directive(ARGS);
+		p = p->next;
+	} WHILE_OPT;
+	EXIT;
+}
+
+RET parse_fragment_spread(PARAMS) {
+	INIT(fragment_spread);
+	parse_punct(ARGS, PUNCT_SPREAD); REQ
+	obj->name = parse_fragment_name(ARGS); REQ
+	obj->directives = parse_directives(ARGS); OPT
+	EXIT;
+}
+
+RET parse_variable_definition(PARAMS) {
+	INIT(variable_definition);
+	obj->var = parse_variable(ARGS); REQ
+	parse_punct(ARGS, ':'); REQ
+	obj->type = parse_type(ARGS); REQ
+	obj->default_val = parse_default_value(ARGS); OPT
+	obj->directives = parse_directives(ARGS); OPT
+	EXIT;
+}
+
+RET parse_variable_definitions(PARAMS) {
+	INIT(variable_definitions);
+	parse_punct(ARGS, '('); REQ
+	obj->first = parse_variable_definition(ARGS); REQ
+	struct graphql_variable_definition *p = obj->first;
+	parse_punct(ARGS, ')');
+	while (*err) {
+		*err = NULL;
+		p->next = parse_variable_definition(ARGS); MSG("expected: variable definition or ')'"); REQ
+		p = p->next;
+		parse_punct(ARGS, ')');
+	}
+	EXIT;
+}
+
+RET parse_selection_set(PARAMS);
+
+RET parse_fragment_definition(PARAMS) {
+	INIT(fragment_definition);
+	parse_keyword(ARGS, "fragment", "fragment expected"); REQ
+	obj->name = parse_fragment_name(ARGS); REQ
+	obj->type_cond = parse_type_condition(ARGS); REQ
+	obj->directives = parse_directives(ARGS); OPT
+	obj->sel_set = parse_selection_set(ARGS); REQ
+	EXIT;
+}
+
+RET parse_inline_fragment(PARAMS) {
+	INIT(inline_fragment);
+	parse_punct(ARGS, PUNCT_SPREAD); REQ
+	obj->type_cond = parse_type_condition(ARGS); OPT
+	obj->directives = parse_directives(ARGS); OPT
+	obj->sel_set = parse_selection_set(ARGS); REQ
+	EXIT;
+}
+
+RET parse_field(PARAMS) {
+	INIT(field);
+	obj->alias = parse_alias(ARGS); OPT
+	obj->name = parse_name(ARGS); REQ
+	obj->args = parse_arguments(ARGS); OPT
+	obj->directives = parse_directives(ARGS); OPT
+	obj->sel_set = parse_selection_set(ARGS); OPT
+	EXIT;
+}
+
+RET parse_selection(PARAMS) {
+	INIT(selection);
+	obj->field = parse_field(ARGS); OR
+	obj->frag_spread = parse_fragment_spread(ARGS); OR
+	obj->inline_frag = parse_inline_fragment(ARGS);
+	MSG("expected: field, fragment spread, or inline fragment");
+	EXIT;
+}
+
+RET parse_selection_set(PARAMS) {
+	INIT(selection_set);
+	parse_punct(ARGS, '{'); REQ;
+	obj->first = parse_selection(ARGS); REQ;
+	struct graphql_selection *p = obj->first;
+	parse_punct(ARGS, '}');
+	while (*err) {
+		*err = NULL;
+		p->next = parse_selection(ARGS); MSG("expected: selection or '}'"); REQ;
+		p = p->next;
+		parse_punct(ARGS, '}');
+	}
+	EXIT;
+}
+
+RET parse_operation_type(PARAMS) {
+	INIT(operation_type);
+	const char *errmsg = "expected: query, mutation, or subscription";
+	obj->op_type = parse_keyword(ARGS, "query", errmsg); OR
+	obj->op_type = parse_keyword(ARGS, "mutation", errmsg); OR
+	obj->op_type = parse_keyword(ARGS, "subscription", errmsg);
+	EXIT;
+}
+
+RET parse_operation_definition(PARAMS) {
+	INIT(operation_definition);
+	obj->op_type = parse_operation_type(ARGS);
+	if (!*err) {
+		obj->op_name = parse_name(ARGS); OPT
+		obj->vars = parse_variable_definitions(ARGS); OPT
+		obj->directives = parse_directives(ARGS); OPT
+	} else
+		*err = NULL;
+	obj->sel_set = parse_selection_set(ARGS);
+	if (*err) ROLLBACK(ARGS);
+	EXIT;
+}
+
+RET parse_executable_definition(PARAMS) {
+	INIT(executable_definition);
+	obj->op_def = parse_operation_definition(ARGS); MSG("invalid operation or fragment definition"); OR
+	obj->frag_def = parse_fragment_definition(ARGS); MSG("invalid operation or fragment definition"); 
+	EXIT;
+}
+
+RET parse_executable_document(PARAMS) {
+	INIT(executable_document);
+	obj->first_def = parse_executable_definition(ARGS); REQ
+	struct graphql_executable_definition *p = obj->first_def;
+	do {
+		p->next_def = parse_executable_definition(ARGS);
+		p = p->next_def;
+	} WHILE_OPT;
+	EXIT;
+}
+
+RET parse_definition(PARAMS) {
+	INIT(definition);
+	obj->executable_def = parse_executable_definition(ARGS);
+/*	OR
+	obj->type_system_def = parse_type_system_definition_or_extension(ARGS);
+	// NOTE: Optional type system is not (yet) implemented.
+*/
+	EXIT;
+}
+
+RET parse_document(PARAMS) {
+	INIT(document);
+	obj->first_def = parse_definition(ARGS); REQ
+	struct graphql_definition *p = obj->first_def;
+	do {
+		p->next_def = parse_definition(ARGS);
+		p = p->next_def;
+	} WHILE_OPT;
+	EXIT;
+}
+void *currently_unused = parse_document; // to hide the warning till this is used
 
 /* Convert input string into tokens.
  *
@@ -660,8 +562,8 @@ newchar:
 			goto newchar;
 		}
 		if (COMMENT(c)) {
-			while ((c = *p++) != EOF && !EOF_CHAR(c) && COMMENT_CHAR(c))
-				; // No-op
+			while (!EOF_CHAR(c) && COMMENT_CHAR(c))
+				c = *p++;
 			goto newchar;
 		}
 
@@ -683,7 +585,7 @@ newchar:
 				c = *p++;
 				if (c != '.')
 					return "unrecognized punctuator";
-				c = 0x2026;
+				c = PUNCT_SPREAD;
 			}
 
 			tok = talz(tok_list, struct graphql_token);
@@ -918,6 +820,10 @@ newchar:
 								*b = 0;
 								int code_point = strtol(buf, 0, 16);
 								int bytes = utf8_encode(code_point, rewrite_dest);
+								// note: if bytes == 0
+								// due to encoding failure,
+								// the following will safely
+								// eliminate the invalid char.
 								rewrite_dest += bytes;
 								cpystr(rewrite_dest, q--);
 							}
@@ -1040,6 +946,22 @@ newchar:
 	} while (!EOF_CHAR(c));
 
 	return "unexpected end-of-input encountered";
+}
+
+// Convert lexed tokens into AST.
+const char *graphql_parse(struct list_head *tokens, struct graphql_executable_document **doc) {
+	struct list_head used = LIST_HEAD_INIT(used);
+	const char *err = NULL;
+	*doc = parse_executable_document(tokens, &used, &err);
+	return err;
+}
+
+// Convert input string into AST.
+const char *graphql_lexparse(const tal_t *ctx, const char *input, struct list_head **tokens, struct graphql_executable_document **doc) {
+	const char *err = graphql_lex(ctx, input, tokens);
+	if (!err)
+		err = graphql_parse(*tokens, doc);
+	return err;
 }
 
 

--- a/ccan/graphql/graphql.c
+++ b/ccan/graphql/graphql.c
@@ -682,6 +682,7 @@ newchar:
 			tok->token_string = NULL;
 			tok->source_line = line_num;
 			tok->source_column = start - line_beginning + 1;
+			tok->source_offset = start - input;
 			tok->source_len = p - start;
 
 		} else if (NAME_START(c)) {
@@ -709,6 +710,7 @@ newchar:
 			// Note the end of the name and calculate the length.
 			name_end = p - 1;
 			name_len = name_end - name_begin;
+			tok->source_offset = name_begin - input;
 			tok->source_len = name_len;
 
 			// Copy the token string.
@@ -771,6 +773,7 @@ newchar:
 			tok->token_string = tal_strndup(tok, num_start, num_len);
 			tok->source_line = line_num;
 			tok->source_column = num_start - line_beginning + 1;
+			tok->source_offset = num_start - input;
 			tok->source_len = num_len;
 
 			goto newchar;
@@ -854,6 +857,7 @@ newchar:
 			tok->token_string = tal_strndup(tok, str_begin, str_len);
 			tok->source_line = line_num;
 			tok->source_column = str_begin - line_beginning + 1;
+			tok->source_offset = str_begin - input;
 			tok->source_len = str_len;
 
 			// Process escape sequences. These always shorten the string (so the memory allocation is always enough).
@@ -900,7 +904,10 @@ newchar:
 							break;
 						case 'u': {
 								// Insert escaped character using UTF-8 multi-byte encoding.
-								char buf[] = {*q++, *q++, *q++, *q++, 0};
+								char buf[5], *b = buf;
+								for (int i = 0; i < 4; i++)
+									*b++ = *q++;
+								*b = 0;
 								int code_point = strtol(buf, 0, 16);
 								int bytes = utf8_encode(code_point, rewrite_dest);
 								rewrite_dest += bytes;
@@ -947,7 +954,7 @@ newchar:
 				char *this_indent_start;
 				const char *this_indent_end;
 				const char *common_indent_start = NULL;
-				const char *common_indent_end;
+				const char *common_indent_end = common_indent_start;
 				const char *r;
 				q = tok->token_string;
 				do {

--- a/ccan/graphql/graphql.h
+++ b/ccan/graphql/graphql.h
@@ -8,7 +8,7 @@
 #include <ccan/tal/tal.h>
 
 // Coding constants
-#define GRAPHQL_SUCCESS 0
+#define GRAPHQL_SUCCESS ((const char *)NULL)
 
 // The following structures constitute the AST returned by the parser.
 
@@ -228,11 +228,30 @@ struct graphql_document {
 	void *data; // for application use
 };
 
+enum token_type_enum {
+	NAME		= 'a',
+	INTEGER		= 'i',
+	FLOAT		= 'f',
+	STRING		= 's',
+	PUNCT_BANG	= '!',
+	PUNCT_SH__	= '$',
+	PUNCT_AMP	= '&',
+	PUNCT_LPAR	= '(',
+	PUNCT_RPAR	= ')',
+	PUNCT_COLON	= ':',
+	PUNCT_EQ	= '=',
+	PUNCT_AT	= '@',
+	PUNCT_LBRACKET	= '[',
+	PUNCT_RBRACKET	= ']',
+	PUNCT_LBRACE	= '{',
+	PUNCT_PIPE	= '|',
+	PUNCT_RBRACE	= '}',
+	PUNCT_SPREAD	= 0x2026, // spread operator (triple dot)
+};
 
 struct graphql_token {
-	struct list_node list;
-	unsigned int token_type;
-	unsigned int token_specific;
+	struct list_node node;
+	enum token_type_enum token_type;
 	char *token_string;
 	unsigned int source_line;
 	unsigned int source_column;
@@ -249,19 +268,24 @@ struct graphql_token {
  * RETURN:
  *	GRAPHQL_SUCCESS or an error string.
  */
-const char *graphql_lex(const char *input, const tal_t *ctx, struct list_head **tokens);
+const char *graphql_lex(const tal_t *ctx, const char *input, struct list_head **tokens);
 
 /* The parser.
  * INPUTS:
  *	tokens - the list produced by the lexer
  *	doc - a variable to receive the resulting abstract syntax tree (AST)
+ * OPERATION:
+ *	The token list is emptied during parsing, so far as the parsing
+ *	succeeds. This allows the caller to inspect the line/char position
+ *	of the next token (where the error likely is) and report that hint to
+ *	the user in the form of an error message.
  * RETURN:
  *	GRAPHQL_SUCCESS or an error string.
  */
 const char *graphql_parse(struct list_head *tokens, struct graphql_executable_document **doc);
 
 /* The lexer and parser in one function, for convenience. */
-const char *graphql_lexparse(const char *input, const tal_t *ctx, struct list_head **tokens, struct graphql_executable_document **doc);
+const char *graphql_lexparse(const tal_t *ctx, const char *input, struct list_head **tokens, struct graphql_executable_document **doc);
 
 #endif
 

--- a/ccan/graphql/graphql.h
+++ b/ccan/graphql/graphql.h
@@ -16,24 +16,29 @@ struct graphql_directive {
 	struct graphql_directive *next;
 	struct graphql_token *name;
 	struct graphql_arguments *args;
+	void *data; // for application use
 };
 
 struct graphql_directives {
 	struct graphql_directive *first;
+	void *data; // for application use
 };
 
 struct graphql_named_type {
 	struct graphql_token *name;
+	void *data; // for application use
 };
 
 struct graphql_type {
 	struct graphql_named_type *named;
 //	struct graphql_list_type *list;
 //	struct graphql_non_null_type *non_null;
+	void *data; // for application use
 };
 
 struct graphql_default_value {
 	struct graphql_value *val;
+	void *data; // for application use
 };
 
 struct graphql_variable_definition {
@@ -42,52 +47,64 @@ struct graphql_variable_definition {
 	struct graphql_type *type;
 	struct graphql_default_value *default_val;
 	struct graphql_directives *directives;
+	void *data; // for application use
 };
 
 struct graphql_variable_definitions {
 	struct graphql_variable_definition *first;
+	void *data; // for application use
 };
 
 struct graphql_variable {
 	struct graphql_token *name;
+	void *data; // for application use
 };
 
 struct graphql_object_field {
 	struct graphql_object_field *next;
 	struct graphql_token *name;
 	struct graphql_value *val;
+	void *data; // for application use
 };
 
 struct graphql_object_value {
 	struct graphql_object_field *first;
+	void *data; // for application use
 };
 
 struct graphql_list_value {
 	struct graphql_token *val;
+	void *data; // for application use
 };
 
 struct graphql_enum_value {
 	struct graphql_token *val;
+	void *data; // for application use
 };
 
 struct graphql_null_value {
 	struct graphql_token *val;
+	void *data; // for application use
 };
 
 struct graphql_string_value {
 	struct graphql_token *val;
+	void *data; // for application use
 };
 
 struct graphql_boolean_value {
 	struct graphql_token *val;
+	void *data; // for application use
 };
 
 struct graphql_float_value {
 	struct graphql_token *val;
+	void *data; // for application use
 };
 
 struct graphql_int_value {
 	struct graphql_token *val;
+	void *data; // for application use
 };
 
 struct graphql_value {
@@ -100,20 +117,24 @@ struct graphql_value {
 	struct graphql_enum_value *enum_val;
 	struct graphql_list_value *list_val;
 	struct graphql_object_value *obj_val;
+	void *data; // for application use
 };
 
 struct graphql_inline_fragment {
 	struct graphql_type_condition *type_cond;
 	struct graphql_directives *directives;
 	struct graphql_selection_set *sel_set;
+	void *data; // for application use
 };
 
 struct graphql_type_condition {
 	struct graphql_named_type *named_type;
+	void *data; // for application use
 };
 
 struct graphql_fragment_name {
 	struct graphql_token *name;
+	void *data; // for application use
 };
 
 struct graphql_fragment_definition {
@@ -121,25 +142,30 @@ struct graphql_fragment_definition {
 	struct graphql_type_condition *type_cond;
 	struct graphql_directives *directives;
 	struct graphql_selection_set *sel_set;
+	void *data; // for application use
 };
 
 struct graphql_fragment_spread {
 	struct graphql_fragment_name *name;
 	struct graphql_directives *directives;
+	void *data; // for application use
 };
 
 struct graphql_alias {
 	struct graphql_token *name;
+	void *data; // for application use
 };
 
 struct graphql_argument {
 	struct graphql_argument *next;
 	struct graphql_token *name;
 	struct graphql_value *val;
+	void *data; // for application use
 };
 
 struct graphql_arguments {
 	struct graphql_argument *first;
+	void *data; // for application use
 };
 
 struct graphql_field {
@@ -148,6 +174,7 @@ struct graphql_field {
 	struct graphql_arguments *args;
 	struct graphql_directives *directives;
 	struct graphql_selection_set *sel_set;
+	void *data; // for application use
 };
 
 struct graphql_selection {
@@ -155,14 +182,17 @@ struct graphql_selection {
 	struct graphql_field *field;
 	struct graphql_fragment_spread *frag_spread;
 	struct graphql_inline_fragment *inline_frag;
+	void *data; // for application use
 };
 
 struct graphql_selection_set {
 	struct graphql_selection *first;
+	void *data; // for application use
 };
 
 struct graphql_operation_type {
 	struct graphql_token *op_type;
+	void *data; // for application use
 };
 
 struct graphql_operation_definition {
@@ -171,26 +201,31 @@ struct graphql_operation_definition {
 	struct graphql_variable_definitions *vars;
 	struct graphql_directives *directives;
 	struct graphql_selection_set *sel_set;
+	void *data; // for application use
 };
 
 struct graphql_executable_definition {
 	struct graphql_executable_definition *next_def;
 	struct graphql_operation_definition *op_def;
 	struct graphql_fragment_definition *frag_def;
+	void *data; // for application use
 };
 
 struct graphql_executable_document {
 	struct graphql_executable_definition *first_def;
+	void *data; // for application use
 };
 
 struct graphql_definition {
 	struct graphql_definition *next_def;
 	struct graphql_executable_definition *executable_def;
 	struct graphql_type_system_definition_or_extension *type_system_def;
+	void *data; // for application use
 };
 
 struct graphql_document {
 	struct graphql_definition *first_def;
+	void *data; // for application use
 };
 
 
@@ -201,7 +236,9 @@ struct graphql_token {
 	char *token_string;
 	unsigned int source_line;
 	unsigned int source_column;
+	unsigned int source_offset;
 	unsigned int source_len;
+	void *data; // for application use
 };
 
 /* The lexer.

--- a/ccan/graphql/test/run.c
+++ b/ccan/graphql/test/run.c
@@ -37,7 +37,7 @@ int listlen(struct list_head *tokens);
 int listlen(struct list_head *tokens) {
 	struct graphql_token *tok;
 	int n=0;
-	list_for_each(tokens, tok, list) {
+	list_for_each(tokens, tok, node) {
 		n++;
 	}
 	return n;
@@ -88,74 +88,74 @@ void check_example_3(const char *source) {
 	if (!mute) printf("// Example No. 3\n");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 11);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '{');
 	TEST_CONT(tok->source_line == 1);
 	TEST_CONT(tok->source_column == 1);
 	TEST_CONT(tok->source_len == 1);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "user");
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 3);
 	TEST_CONT(tok->source_len == 4);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '(');
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 7);
 	TEST_CONT(tok->source_len == 1);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 8);
 	TEST_CONT(tok->source_len == 2);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == ':');
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 10);
 	TEST_CONT(tok->source_len == 1);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "4");
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 12);
 	TEST_CONT(tok->source_len == 1);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == ')');
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 13);
 	TEST_CONT(tok->source_len == 1);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '{');
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 15);
 	TEST_CONT(tok->source_len == 1);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "name");
 	TEST_CONT(tok->source_line == 3);
 	TEST_CONT(tok->source_column == 5);
 	TEST_CONT(tok->source_len == 4);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '}');
 	TEST_CONT(tok->source_line == 4);
 	TEST_CONT(tok->source_column == 3);
 	TEST_CONT(tok->source_len == 1);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '}');
 	TEST_CONT(tok->source_line == 5);
 	TEST_CONT(tok->source_column == 1);
 	TEST_CONT(tok->source_len == 1);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -221,63 +221,63 @@ mutation {\n\
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 15);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "mutation");
 	TEST_CONT(tok->source_line == 1);
 	TEST_CONT(tok->source_column == 1);
 	TEST_CONT(tok->source_len == 8);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "likeStory");
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 3);
 	TEST_CONT(tok->source_len == 9);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "storyID");
 	TEST_CONT(tok->source_line == 2);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "12345");
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 22);
 	TEST_CONT(tok->source_len == 5);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "story");
 	TEST_CONT(tok->source_line == 3);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "likeCount");
 	TEST_CONT(tok->source_line == 4);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -354,25 +354,25 @@ void check_example_6(char *source) {
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 3);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "field");
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 3);
 	TEST_CONT(tok->source_len == 5);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -414,37 +414,37 @@ void check_example_7(char *source) {
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 5);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 3);
 	TEST_CONT(tok->source_len == 2);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "firstName");
 	TEST_CONT(tok->source_line == 3);
 	TEST_CONT(tok->source_column == 3);
 	TEST_CONT(tok->source_len == 9);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "lastName");
 	TEST_CONT(tok->source_line == 4);
 	TEST_CONT(tok->source_column == 3);
 	TEST_CONT(tok->source_len == 8);
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list);
+	tok = list_pop(tokens, struct graphql_token, node);
 	TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -517,40 +517,40 @@ void check_example_8(char *source) {
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 17);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "me");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "firstName");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "lastName");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "birthday");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "month");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "day");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "friends");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "name");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -686,38 +686,38 @@ void check_example_9(char *source) {
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 17);
 	// NOTE: Comments are ignored.
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "me");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "name");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "user");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "4");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "name");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -816,40 +816,40 @@ void check_example_10(char *source) {
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 18);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "user");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "4");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "name");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "profilePic");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "size");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "100");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -947,46 +947,46 @@ void check_example_11(char *source) {
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 21);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "user");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "4");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "name");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "profilePic");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "width");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "100");
 	// NOTE: Comma is ignored.
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "height");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "50");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -1083,33 +1083,33 @@ void check_example_12_and_13(const char *source) {
 
 	// Test the lexer.
 	const char *param;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 11);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "picture");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_ABRT(tok->token_string != NULL && (streq(tok->token_string, "width") || streq(tok->token_string, "height")));
 	param = tok->token_string;
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_CONT(tok->token_string != NULL && ((streq(param, "width") && streq(tok->token_string, "200")) || (streq(param, "height") && streq(tok->token_string, "100"))));
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_CONT(tok->token_string != NULL && (streq(tok->token_string, "width") || streq(tok->token_string, "height")));
 	param = tok->token_string;
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_CONT(tok->token_string != NULL && ((streq(param, "width") && streq(tok->token_string, "200")) || (streq(param, "height") && streq(tok->token_string, "100"))));
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_argument *arg;
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -1177,55 +1177,55 @@ void check_example_14(char *source) {
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 28);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "user");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "4");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "name");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "smallPic");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "profilePic");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "size");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "64");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "bigPic");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "profilePic");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "size");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "1024");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -1349,34 +1349,34 @@ void check_example_16(char *source) {
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 14);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "zuck");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "user");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, "4");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "name");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -1462,13 +1462,13 @@ query noFragments {\n\
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 44);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -1522,26 +1522,26 @@ fragment friendFields on User {\n\
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 46);
 	for (int i=0; i<17; i++)
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 0x2026);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 0x2026);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "friendFields");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
 	for (int i=0; i<7; i++)
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 0x2026);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 0x2026);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "friendFields");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
 	const char *e;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT((e = graphql_parse(tokens, &doc)) == NULL);
 	if (e) printf("%s\n", e);
 	TEST_ABRT(doc != NULL);
@@ -1632,26 +1632,26 @@ fragment standardProfilePic on User {\n\
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 54);
 	for (int i=0; i<17; i++)
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 0x2026);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 0x2026);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "friendFields");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
 	for (int i=0; i<7; i++)
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 0x2026);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 0x2026);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "friendFields");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
 	const char *e;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT((e = graphql_parse(tokens, &doc)) == NULL);
 	if (e) printf("%s\n", e);
 	TEST_ABRT(doc != NULL);
@@ -1766,33 +1766,33 @@ fragment pageFragment on Page {\n\
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 40);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "query");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "FragmentTyping");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "profiles");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "handles");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '[');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 's');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '[');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 's');
 	TEST_STRG(tok->token_string, "zuck");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 's');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 's');
 	TEST_STRG(tok->token_string, "coca-cola");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ']');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ']');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
 	const char *e;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT((e = graphql_parse(tokens, &doc)) == NULL);
 	if (e) printf("%s\n", e);
 	TEST_ABRT(doc != NULL);
@@ -1890,33 +1890,33 @@ query inlineFragmentTyping {\n\
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 34);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "query");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "inlineFragmentTyping");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "profiles");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "handles");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '[');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 's');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '[');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 's');
 	TEST_STRG(tok->token_string, "zuck");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 's');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 's');
 	TEST_STRG(tok->token_string, "coca-cola");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ']');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ']');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
 	const char *e;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT((e = graphql_parse(tokens, &doc)) == NULL);
 	if (e) printf("%s\n", e);
 	TEST_ABRT(doc != NULL);
@@ -1989,62 +1989,62 @@ query inlineFragmentNoType($expandedInfo: Boolean) {\n\
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 34);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "query");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "inlineFragmentNoType");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '$');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '$');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "expandedInfo");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "Boolean");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "user");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "handle");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 's');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 's');
 	TEST_STRG(tok->token_string, "zuck");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "id");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "name");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 0x2026);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '@');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 0x2026);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '@');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "include");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "if");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '$');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '$');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "expandedInfo");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "firstName");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "lastName");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "birthday");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -2125,32 +2125,32 @@ void check_int_value(char *source, int int_value) {
 	sprintf(buf, "%d", int_value);
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 11);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
 	TEST_STRG(tok->token_string, buf);
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 12);
 	TEST_CONT(tok->source_len == strlen(buf));
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 12 + strlen(buf));
 	TEST_CONT(tok->source_len == 1);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -2193,7 +2193,7 @@ void check_invalid_int_values(char *source) {
 		", bad_values[i]);
 
 		// Test the lexer.
-		TEST_CONT(graphql_lex(source, NULL, &tokens) != NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) != NULL);
 		TEST_ABRT(listlen(tokens) == 5);
 		tokens = tal_free(tokens);
 
@@ -2219,32 +2219,32 @@ void check_float_value(char *source, float float_value, const char *format) {
 	sprintf(buf, format, float_value);
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 11);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'f');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'f');
 	TEST_STRG(tok->token_string, buf);
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 12);
 	TEST_CONT(tok->source_len == strlen(buf));
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
 	TEST_CONT(tok->source_line == 2);
 	TEST_CONT(tok->source_column == 12 + strlen(buf));
 	TEST_CONT(tok->source_len == 1);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -2288,32 +2288,32 @@ void check_valid_float_values(char *source) {
 		", good_values[i]);
 
 		// Test the lexer.
-		TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 		TEST_ABRT(listlen(tokens) == 11);
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'f');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'f');
 		TEST_STRG(tok->token_string, good_values[i]);
 		TEST_CONT(tok->source_line == 2);
 		TEST_CONT(tok->source_column == 12);
 		TEST_CONT(tok->source_len == strlen(good_values[i]));
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
 		TEST_CONT(tok->source_line == 2);
 		TEST_CONT(tok->source_column == 12 + strlen(good_values[i]));
 		TEST_CONT(tok->source_len == 1);
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 		tokens = tal_free(tokens);
 
 		// Test the parser.
 		struct graphql_executable_document *doc;
-		TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 		TEST_CONT(graphql_parse(tokens, &doc) == NULL);
 		TEST_ABRT(doc != NULL);
 		TEST_ABRT(doc->first_def != NULL);
@@ -2357,7 +2357,7 @@ void check_invalid_float_values(char *source) {
 		", bad_values[i]);
 
 		// Test the lexer.
-		TEST_CONT(graphql_lex(source, NULL, &tokens) != NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) != NULL);
 		TEST_ABRT(listlen(tokens) == 5);
 		tokens = tal_free(tokens);
 
@@ -2382,13 +2382,13 @@ void check_boolean_values(char *source) {
 		", good_values[i]);
 
 		// Test the lexer.
-		TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 		TEST_ABRT(listlen(tokens) == 11);
 		tokens = tal_free(tokens);
 
 		// Test the parser.
 		struct graphql_executable_document *doc;
-		TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 		TEST_CONT(graphql_parse(tokens, &doc) == NULL);
 		TEST_ABRT(doc != NULL);
 		TEST_ABRT(doc->first_def != NULL);
@@ -2426,13 +2426,13 @@ void check_boolean_values(char *source) {
 		", bad_values[i]);
 
 		// Test the lexer.
-		TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 		TEST_ABRT(listlen(tokens) == 11);
 		tokens = tal_free(tokens);
 
 		// Test the parser (it will succeed in parsing the bad values as enum values, not boolean values).
 		struct graphql_executable_document *doc;
-		TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 		TEST_CONT(graphql_parse(tokens, &doc) == NULL);
 		TEST_ABRT(doc != NULL);
 		TEST_ABRT(doc->first_def != NULL);
@@ -2483,32 +2483,32 @@ void check_string_value(char *source, const char *test_value, const char *expect
 
 	bool block = (test_value[0]=='\"' && test_value[1]=='\"' && test_value[2]=='\"')? true: false;
 	if (expected_result) {
-		TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 		TEST_ABRT(listlen(tokens) == 11);
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 's');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 's');
 		TEST_STRG(tok->token_string, expected_result);
 		TEST_CONT(tok->source_line == 2);
 		TEST_CONT(tok->source_column == 11 + (block? 3: 1));
 		TEST_CONT(tok->source_len == strlen(test_value) - (block? 6: 2));
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
 		TEST_CONT(tok->source_line == 2);
 		TEST_CONT(tok->source_column == 11 + strlen(test_value));
 		TEST_CONT(tok->source_len == 1);
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 		tokens = tal_free(tokens);
 
 		// Test the parser (it will succeed in parsing the bad values as enum values, not boolean values).
 		struct graphql_executable_document *doc;
-		TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 		TEST_CONT(graphql_parse(tokens, &doc) == NULL);
 		TEST_ABRT(doc != NULL);
 		TEST_ABRT(doc->first_def != NULL);
@@ -2541,7 +2541,7 @@ void check_string_value(char *source, const char *test_value, const char *expect
 		TEST_ABRT(doc->first_def->op_def->sel_set->first->field->sel_set->first->field != NULL);
 		tokens = tal_free(tokens);
 	} else {
-		TEST_CONT(graphql_lex(source, NULL, &tokens) != NULL);
+		TEST_CONT(graphql_lex(NULL, source, &tokens) != NULL);
 		tokens = tal_free(tokens);
 	}
 }
@@ -2552,8 +2552,8 @@ void check_example_25_and_26(const char *source) {
 
 	if (!mute) printf("// Example No. 25 and 26\n");
 
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
-	while ((tok = list_pop(tokens, struct graphql_token, list)) && tok->token_type != 's') { }
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
+	while ((tok = list_pop(tokens, struct graphql_token, node)) && tok->token_type != 's') { }
 	if (tok) {
 		TEST_STRG(tok->token_string, "Hello,\n  World!\n\nYours,\n  GraphQL.");
 	}
@@ -2562,7 +2562,7 @@ void check_example_25_and_26(const char *source) {
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	tokens = tal_free(tokens);
@@ -2582,24 +2582,24 @@ void check_example_29(char *source) {
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 9);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "null");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -2658,25 +2658,25 @@ void check_example_30_and_31(const char *source) {
 
 	if (!mute) printf("// Example No. 30 and 31\n");
 
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 15);
-	while ((tok = list_pop(tokens, struct graphql_token, list)) && !(tok->token_type == 'a' && tok->token_string != NULL && streq(tok->token_string, "lat"))) { }
+	while ((tok = list_pop(tokens, struct graphql_token, node)) && !(tok->token_type == 'a' && tok->token_string != NULL && streq(tok->token_string, "lat"))) { }
 	TEST_CONT(tok);
 	if (tok) {
 		TEST_CONT(tok->token_type == 'a');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'f');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'f');
 		TEST_STRG(tok->token_string, "-53.211");
 	}
 	tokens = tal_free(tokens);
 
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
-	while ((tok = list_pop(tokens, struct graphql_token, list)) && !(tok->token_type == 'a' && tok->token_string != NULL && streq(tok->token_string, "lon"))) { }
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
+	while ((tok = list_pop(tokens, struct graphql_token, node)) && !(tok->token_type == 'a' && tok->token_string != NULL && streq(tok->token_string, "lon"))) { }
 	TEST_CONT(tok);
 	if (tok) {
 		TEST_CONT(tok->token_type == 'a');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-		tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'f');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+		tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'f');
 		TEST_STRG(tok->token_string, "12.43");
 	}
 	tokens = tal_free(tokens);
@@ -2684,7 +2684,7 @@ void check_example_30_and_31(const char *source) {
 	// Test the parser.
 	struct graphql_executable_document *doc;
 	const char *e;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT((e = graphql_parse(tokens, &doc)) == NULL);
 	if (e) printf("%s\n", e);
 	TEST_ABRT(doc != NULL);
@@ -2759,41 +2759,41 @@ query getZuckProfile($devicePicSize: Int) {\n\
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 27);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '$');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'i');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '$');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '$');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'i');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '$');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// Test the parser.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(graphql_parse(tokens, &doc) == NULL);
 	TEST_ABRT(doc != NULL);
 	TEST_ABRT(doc->first_def != NULL);
@@ -2909,38 +2909,38 @@ type Person\n\
 	");
 
 	// Test the lexer.
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 21);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '@');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '@');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "addExternalFields");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 's');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '@');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 's');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '@');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "excludeField");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 's');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 's');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// The type system is not yet implemented, so parsing will fail here.
 	// This could be "phase 2" of this project.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT(graphql_parse(tokens, &doc) != NULL);
 	tokens = tal_free(tokens);
 }
@@ -2959,38 +2959,38 @@ type Person\n\
 }\n\
 	");
 
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_ABRT(listlen(tokens) == 21);
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '@');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '@');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "excludeField");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 's');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '@');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 's');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '@');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
 	TEST_STRG(tok->token_string, "addExternalFields");
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '(');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 's');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ')');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '{');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == ':');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == 'a');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok->token_type == '}');
-	tok = list_pop(tokens, struct graphql_token, list); TEST_CONT(tok == NULL);
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '(');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 's');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ')');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '{');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == ':');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == 'a');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok->token_type == '}');
+	tok = list_pop(tokens, struct graphql_token, node); TEST_CONT(tok == NULL);
 	tokens = tal_free(tokens);
 
 	// The type system is not yet implemented, so parsing will fail here.
 	// This could be "phase 2" of this project.
 	struct graphql_executable_document *doc;
-	TEST_CONT(graphql_lex(source, NULL, &tokens) == NULL);
+	TEST_CONT(graphql_lex(NULL, source, &tokens) == NULL);
 	TEST_CONT(graphql_parse(tokens, &doc) != NULL);
 	tokens = tal_free(tokens);
 }


### PR DESCRIPTION
This PR adds convenience fields to the syntax tree returned by the GraphQL parser to allow application data to be associated with the nodes of the tree. It also fixes a warning and adds an offset field to the token struct.