### PR TITLE
minmax: don't nest min/max in clamp to avoid -Wshadow warnings

### DIFF
--- a/ccan/minmax/minmax.h
+++ b/ccan/minmax/minmax.h
@@ -38,7 +38,11 @@
 		_a > _b ? _a : _b; \
 	})
 
-#define clamp(v, f, c)	(max(min((v), (c)), (f)))
+#define clamp(v, f, c) \
+	({ \
+		typeof(v) _ceiling_clamped = min((v), (c)); \
+		(max(_ceiling_clamped, (f))); \
+	})
 
 
 #define min_t(t, a, b) \


### PR DESCRIPTION
Using clamp from minmax.h with -Wshadow (GCC 11 and 8, haven't tested others)
generates a bunch of warnings because min and max both declare _a, _b vars.
Store the result of min to a temporary variable instead of nesting the calls
this way min's variables are not in scope of max.

Signed-off-by: Jakub Kicinski <kuba@kernel.org>