### PR TITLE
Fix typos detected by codespell

### DIFF
--- a/ccan/aga/aga.h
+++ b/ccan/aga/aga.h
@@ -68,7 +68,7 @@
  *   callback itself.  If the latter, it MUST have been initialized
  *   with aga_node_init() before the edge callback returns.
  *
- * - If a node is contructed by the edge callback, any subsequent
+ * - If a node is constructed by the edge callback, any subsequent
  *   reference to that node by the edge callback for *any* node and
  *   index MUST use the same pointer.
  *
@@ -107,7 +107,7 @@
  * - After an error is encountered aga_error() will return a non-zero
  *   value.  Negative values are reserved for errors reported by the
  *   user supplied edge callback.  Positive values are reserved for
- *   errors detected interally by aga.
+ *   errors detected internally by aga.
  *
  * - Errors are cleared on aga_finish().
  */
@@ -245,7 +245,7 @@ enum aga_error {
  *
  * Returns 0 if the graph is not in an error state, negative values
  * for error states reported by one of the edge callbacks and
- * postitive values for errors detected by aga itself.
+ * positive values for errors detected by aga itself.
  */
 int aga_error(const struct aga_graph *g);
 

--- a/ccan/alignof/_info
+++ b/ccan/alignof/_info
@@ -11,7 +11,7 @@
  * alignment may cause performance loss or even program failure (eg. a
  * bus signal).
  *
- * There are times which it's useful to be able to programatically
+ * There are times which it's useful to be able to programmatically
  * access these requirements, such as for dynamic allocators.
  *
  * Example:

--- a/ccan/antithread/antithread.c
+++ b/ccan/antithread/antithread.c
@@ -152,7 +152,7 @@ static void talloc_unlock(void)
 /* We add 16MB to size.  This compensates for address randomization. */
 #define PADDING (16 * 1024 * 1024)
 
-/* Create a new sharable pool. */
+/* Create a new shareable pool. */
 struct at_pool *at_pool(unsigned long size)
 {
 	int fd;

--- a/ccan/antithread/antithread.h
+++ b/ccan/antithread/antithread.h
@@ -8,7 +8,7 @@ struct athread;
 
 /* Operations for the parent. */
 
-/* Create a new sharable pool. */
+/* Create a new shareable pool. */
 struct at_pool *at_pool(unsigned long size);
 
 /* Talloc off this to allocate from within the pool. */

--- a/ccan/antithread/examples/arabella.c
+++ b/ccan/antithread/examples/arabella.c
@@ -128,7 +128,7 @@ static void paint_triangle(struct image *image, const struct triangle *tri)
         x1 = tri->coord[i1].x, y1 = tri->coord[i1].y;
         x2 = tri->coord[i2].x, y2 = tri->coord[i2].y;
         
-        // test for easy cases, else split triangle in two and render both halfs
+        // test for easy cases, else split triangle in two and render both halves
         if (y1 == y2) {
  		if (x1 > x2) swap(&x1, &x2);
 		add_flat_triangle(image, x1, y1, x2, y2, x0, y0,

--- a/ccan/argcheck/argcheck.h
+++ b/ccan/argcheck/argcheck.h
@@ -171,7 +171,7 @@ argcheck_log_(const char *file, int line, const char *func,
 
 /*
 
-   below is the actual implemenation. do not use it directly, use the macros
+   below is the actual implementation. do not use it directly, use the macros
    above instead
 
  */

--- a/ccan/autodata/_info
+++ b/ccan/autodata/_info
@@ -9,7 +9,7 @@
  * together at runtime to form tables.  This is often used in place of
  * having a central registration function or table.
  *
- * Note that this technique does not work in general for shared libaries,
+ * Note that this technique does not work in general for shared libraries,
  * only for code compiled into a binary.
  *
  * License: BSD-MIT

--- a/ccan/bdelta/bdelta.c
+++ b/ccan/bdelta/bdelta.c
@@ -381,7 +381,7 @@ static BDELTAcode build_triangle(
 	 *
 	 *  * Every V array is preserved per iteration of the outer loop.
 	 *    This is necessary so we can determine the actual patch, not just
-	 *    the length of the shortest edit string.  See the coment above
+	 *    the length of the shortest edit string.  See the comment above
 	 *    the definition of Triangle for an in-depth explanation.
 	 *
 	 *  * Array items are stored consecutively so as to not waste space.

--- a/ccan/check_type/_info
+++ b/ccan/check_type/_info
@@ -11,7 +11,7 @@
  * a precise type isn't used.
  *
  * On compilers which don't support typeof() these routines are less effective,
- * since they have to use sizeof() which can only distiguish between types of
+ * since they have to use sizeof() which can only distinguish between types of
  * different size.
  *
  * License: CC0 (Public domain)

--- a/ccan/coroutine/coroutine.h
+++ b/ccan/coroutine/coroutine.h
@@ -173,7 +173,7 @@ coroutine_stack_from_metadata(void *metadata, size_t metasize)
  * @stack: coroutine stack
  *
  * Returns the size of the coroutine stack @stack.  This does not
- * include the overhead of struct coroutine_stack or metdata.
+ * include the overhead of struct coroutine_stack or metadata.
  */
 size_t coroutine_stack_size(const struct coroutine_stack *stack);
 

--- a/ccan/cpuid/cpuid.h
+++ b/ccan/cpuid/cpuid.h
@@ -59,7 +59,7 @@
  * 	Extended L2 Cache features.
  *
  * %CPUID_ADV_POWER_MGT_INFO:
- * 	Advaned power management information.
+ * 	Advanced power management information.
  *
  * %CPUID_VIRT_PHYS_ADDR_SIZES:
  * 	Virtual and physical address sizes.

--- a/ccan/crc32c/crc32c.c
+++ b/ccan/crc32c/crc32c.c
@@ -407,11 +407,11 @@ static uint32_t crc32c_sw_big(uint32_t crc, void const *buf, size_t len) {
 }
 
 /* Table-driven software CRC-32C.  This is about 15 times slower than using the
-   hardware instructions.  Determine the endianess of the processor and proceed
-   accordingly.  Ideally the endianess will be determined at compile time, in
-   which case the unused functions and tables for the other endianess will be
+   hardware instructions.  Determine the endianness of the processor and proceed
+   accordingly.  Ideally the endianness will be determined at compile time, in
+   which case the unused functions and tables for the other endianness will be
    removed by the optimizer.  If not, then the proper routines and tables will
-   be used, even if the endianess is changed mid-stream.  (Yes, there are
+   be used, even if the endianness is changed mid-stream.  (Yes, there are
    processors that permit that -- go figure.) */
 static uint32_t crc32c_sw(uint32_t crc, void const *buf, size_t len) {
     static int const little = 1;

--- a/ccan/crypto/hmac_sha256/_info
+++ b/ccan/crypto/hmac_sha256/_info
@@ -16,7 +16,7 @@
  *	#include <stdio.h>
  *	#include <string.h>
  *
- *	// Simple demonstration: idential strings will have the same hash, but
+ *	// Simple demonstration: identical strings will have the same hash, but
  *	// two different strings will not.
  *	int main(int argc, char *argv[])
  *	{

--- a/ccan/crypto/ripemd160/_info
+++ b/ccan/crypto/ripemd160/_info
@@ -17,7 +17,7 @@
  *	#include <stdio.h>
  *	#include <string.h>
  *
- *	// Simple demonstration: idential strings will have the same hash, but
+ *	// Simple demonstration: identical strings will have the same hash, but
  *	// two different strings will not.
  *	int main(int argc, char *argv[])
  *	{

--- a/ccan/crypto/ripemd160/ripemd160.h
+++ b/ccan/crypto/ripemd160/ripemd160.h
@@ -82,7 +82,7 @@ void ripemd160_init(struct ripemd160_ctx *ctx);
 /**
  * RIPEMD160_INIT - initializer for an RIPEMD160 context.
  *
- * This can be used to staticly initialize an RIPEMD160 context (instead
+ * This can be used to statically initialize an RIPEMD160 context (instead
  * of ripemd160_init()).
  *
  * Example:

--- a/ccan/crypto/sha256/_info
+++ b/ccan/crypto/sha256/_info
@@ -17,7 +17,7 @@
  *	#include <stdio.h>
  *	#include <string.h>
  *
- *	// Simple demonstration: idential strings will have the same hash, but
+ *	// Simple demonstration: identical strings will have the same hash, but
  *	// two different strings will not.
  *	int main(int argc, char *argv[])
  *	{

--- a/ccan/crypto/sha256/benchmarks/sha256_avx2_rorx8.asm
+++ b/ccan/crypto/sha256/benchmarks/sha256_avx2_rorx8.asm
@@ -125,7 +125,7 @@ _IDX_LIMIT_SIZE	equ 8
 _RSP_SIZE	equ 8
 
 ;; KTMSG must overlap TMSG such that the second 3/4 of KTMSG overlaps the
-;; first 3/4 of TMSG. (We onl need 16 words of TMSG at any time.)
+;; first 3/4 of TMSG. (We only need 16 words of TMSG at any time.)
 _KTMSG		equ              _EXTRA_SIZE
 _TMSG		equ _KTMSG     + _KTMSG_SIZE
 _XMM_SAVE	equ _TMSG      + _TMSG_SIZE

--- a/ccan/crypto/siphash24/siphash24.h
+++ b/ccan/crypto/siphash24/siphash24.h
@@ -80,7 +80,7 @@ void siphash24_init(struct siphash24_ctx *ctx, const struct siphash_seed *seed);
  * SIPHASH24_INIT - initializer for an SIPHASH24 context.
  * @seed1, @seed2: two 64-bit words for seed.
  *
- * This can be used to staticly initialize an SIPHASH24 context (instead
+ * This can be used to statically initialize an SIPHASH24 context (instead
  * of siphash24_init()).
  *
  * Example:

--- a/ccan/crypto/siphash24/test/run.c
+++ b/ccan/crypto/siphash24/test/run.c
@@ -98,7 +98,7 @@ int main(void)
 	/* This is how many tests you plan to run */
 	plan_tests(1 + MAXLEN * 2);
 
-	/* Initialzed an manually created should give same results. */
+	/* Initialized and manually created should give same results. */
 	for (i = 0; i < sizeof(seed.u.u8); i++)
 		seed.u.u8[i] = i;
 	siphash24_init(&ctx2, &seed);

--- a/ccan/dgraph/dgraph.c
+++ b/ccan/dgraph/dgraph.c
@@ -126,7 +126,7 @@ static bool dgraph_check_node(struct dgraph_node *n, void *info_)
 					continue;
 				if (info->abortstr) {
 					fprintf(stderr,
-						"%s: node %p %s edge doesnt"
+						"%s: node %p %s edge doesn't"
 						" point back to %p\n",
 						info->abortstr, e->n[!dir],
 						!dir == DGRAPH_FROM

--- a/ccan/dgraph/dgraph.h
+++ b/ccan/dgraph/dgraph.h
@@ -11,7 +11,7 @@ enum dgraph_dir {
 	DGRAPH_TO
 };
 
-/* strust tlist_dgraph_edge: a list of edges */
+/* struct tlist_dgraph_edge: a list of edges */
 TLIST_TYPE(dgraph_edge, struct dgraph_edge);
 
 /**

--- a/ccan/graphql/test/run.c
+++ b/ccan/graphql/test/run.c
@@ -3105,7 +3105,7 @@ int main(void)
 	RUN2(check_string_value, "\"te\\tst\"",              "te\tst"     ); // Check escape sequence.
 	RUN2(check_string_value, "\"te\\vst\"",              NULL         ); // Invalid escape sequence.
 	RUN2(check_string_value, "\"te\\033st\"",            NULL         ); // Invalid escape sequence.
-	// Note: Unicode excape sequence is tested below.
+	// Note: Unicode escape sequence is tested below.
 
 	// This block string and this string should result in identical tokens.
 	sprintf(source, "\

--- a/ccan/hash/hash.h
+++ b/ccan/hash/hash.h
@@ -35,7 +35,7 @@
  *	#include <stdio.h>
  *	#include <string.h>
  *
- *	// Simple demonstration: idential strings will have the same hash, but
+ *	// Simple demonstration: identical strings will have the same hash, but
  *	// two different strings will probably not.
  *	int main(int argc, char *argv[])
  *	{
@@ -164,7 +164,7 @@ static inline uint32_t hash_string(const char *string)
  *	#include <stdio.h>
  *	#include <string.h>
  *
- *	// Simple demonstration: idential strings will have the same hash, but
+ *	// Simple demonstration: identical strings will have the same hash, but
  *	// two different strings will probably not.
  *	int main(int argc, char *argv[])
  *	{

--- a/ccan/idtree/_info
+++ b/ccan/idtree/_info
@@ -18,7 +18,7 @@
  *	#include <stdlib.h>
  *	#include <stdio.h>
  *
- *	// Silly example which puts args in the idtree and retreives them
+ *	// Silly example which puts args in the idtree and retrieves them
  *	int main(int argc, char *argv[])
  *	{
  *		struct idtree *idtree = idtree_new(NULL);

--- a/ccan/io/benchmarks/run-loop.c
+++ b/ccan/io/benchmarks/run-loop.c
@@ -78,7 +78,7 @@ int main(void)
 		last_read = fds[0];
 	}
 
-	/* Last one completes the cirle. */
+	/* Last one completes the circle. */
 	i = 0;
 	buf[i].iters = 0;
 	sprintf(buf[i].buf, "%i-%i", i, i);

--- a/ccan/io/test/run-10-many.c
+++ b/ccan/io/test/run-10-many.c
@@ -92,7 +92,7 @@ int main(void)
 	if (!ok1(i == NUM))
 		exit(exit_status());
 
-	/* Last one completes the cirle. */
+	/* Last one completes the circle. */
 	i = 0;
 	sprintf(buf[i].buf, "%i-%i", i, i);
 	buf[i].reader = io_new_conn(NULL, last_read, setup_reader, &buf[i]);

--- a/ccan/isaac/_info
+++ b/ccan/isaac/_info
@@ -73,7 +73,7 @@
  * It is the fastest 32-bit generator among all of those that pass the
  * statistical tests in the recent survey
  * http://www.iro.umontreal.ca/~simardr/testu01/tu01.html, with the exception
- * of Marsa-LFIB4, and it is quite competitive on 64-bit archtectures.
+ * of Marsa-LFIB4, and it is quite competitive on 64-bit architectures.
  *
  * Unlike Marsa-LFIB4 (and all other LFib generators), there are no linear
  * dependencies between successive values, and unlike many generators found in

--- a/ccan/iscsi/iscsi.h
+++ b/ccan/iscsi/iscsi.h
@@ -227,7 +227,7 @@ int iscsi_nop_out_async(struct iscsi_context *iscsi, iscsi_command_cb cb, unsign
  * The content of command_data depends on the status type.
  *
  * status :
- *   ISCSI_STATUS_GOOD the scsi command completed successfullt on the target.
+ *   ISCSI_STATUS_GOOD the scsi command completed successfully on the target.
  *   If this scsi command returns DATA-IN, that data is stored in an scsi_task structure
  *   returned in the command_data parameter. This buffer will be automatically freed once the callback
  *   returns.

--- a/ccan/iscsi/login.c
+++ b/ccan/iscsi/login.c
@@ -280,7 +280,7 @@ int iscsi_process_logout_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pd
 int iscsi_set_session_type(struct iscsi_context *iscsi, enum iscsi_session_type session_type)
 {
 	if (iscsi == NULL) {
-		printf("Trying to set sesssion type on NULL context\n");
+		printf("Trying to set session type on NULL context\n");
 		return -1;
 	}
 	if (iscsi->is_loggedin) {

--- a/ccan/iscsi/pdu.c
+++ b/ccan/iscsi/pdu.c
@@ -168,7 +168,7 @@ int iscsi_process_pdu(struct iscsi_context *iscsi, const unsigned char *hdr, int
 	itt = ntohl(*(uint32_t *)&hdr[16]);
 
 	if (ahslen != 0) {
-		printf("cant handle expanded headers yet\n");
+		printf("can't handle expanded headers yet\n");
 		return -1;
 	}
 

--- a/ccan/iscsi/scsi-command.c
+++ b/ccan/iscsi/scsi-command.c
@@ -58,7 +58,7 @@ static void iscsi_scsi_response_cb(struct iscsi_context *iscsi, int status, void
 		scsi_cbdata->callback(iscsi, ISCSI_STATUS_GOOD, task, scsi_cbdata->private_data);
 		return;
 	default:
-		printf("Cant handle  scsi status %d yet\n", status);
+		printf("Can't handle  scsi status %d yet\n", status);
 		scsi_cbdata->callback(iscsi, ISCSI_STATUS_ERROR, task, scsi_cbdata->private_data);
 	}
 }

--- a/ccan/iscsi/tools/iscsiclient.c
+++ b/ccan/iscsi/tools/iscsiclient.c
@@ -83,7 +83,7 @@ void read10_cb(struct iscsi_context *iscsi, int status, void *command_data, void
 	}
 	printf("...\n");
 
-	printf("Finished,   wont try to write data since that will likely destroy your LUN :-(\n");
+	printf("Finished,   won't try to write data since that will likely destroy your LUN :-(\n");
 	printf("Send NOP-OUT\n");
 	if (iscsi_nop_out_async(iscsi, nop_out_cb, "Ping!", 6, private_data) != 0) {
 		printf("failed to send nop-out\n");

--- a/ccan/jmap/jmap.h
+++ b/ccan/jmap/jmap.h
@@ -364,7 +364,7 @@ struct jmap {
  * @map: map from jmap_new
  * @p: the pointer to a pointer to the value
  *
- * @p is a pointer to the (successful) value retuned from one of the
+ * @p is a pointer to the (successful) value returned from one of the
  * jmap_*val functions (listed below).  After this, it will be invalid.
  *
  * Unless NDEBUG is defined, this will actually alter the value of p

--- a/ccan/lbalance/_info
+++ b/ccan/lbalance/_info
@@ -14,7 +14,7 @@
  *
  * Example:
  *	// Run 1000 of the given commandline at best-known parallel rate.
- *	// See tools/lbalance.c for a sligtly more serious example.
+ *	// See tools/lbalance.c for a slightly more serious example.
  *	#include <ccan/lbalance/lbalance.h>
  *      #include <sys/types.h>
  *      #include <sys/time.h>

--- a/ccan/list/list.h
+++ b/ccan/list/list.h
@@ -712,7 +712,7 @@ static inline void list_prepend_list_(struct list_head *to,
  * @off: offset(relative to @i) at which list node data resides.
  *
  * This is a low-level wrapper to iterate @i over the entire list, used to
- * implement all oher, more high-level, for-each constructs. It's a for loop,
+ * implement all other, more high-level, for-each constructs. It's a for loop,
  * so you can break and continue as normal.
  *
  * WARNING! Being the low-level macro that it is, this wrapper doesn't know

--- a/ccan/lstack/lstack.h
+++ b/ccan/lstack/lstack.h
@@ -10,7 +10,7 @@
 
 /**
  * struct lstack_link - a stack link
- * @down: immedately lower entry in the stack, or NULL if this is the bottom.
+ * @down: immediately lower entry in the stack, or NULL if this is the bottom.
  *
  * This is used as an entry in a stack.
  *

--- a/ccan/nfs/libnfs-raw.h
+++ b/ccan/nfs/libnfs-raw.h
@@ -57,7 +57,7 @@ typedef void (*rpc_cb)(struct rpc_context *rpc, int status, void *data, void *pr
  * RPC_STATUS_SUCCESS : The tcp connection was successfully established.
  *                      data is NULL.
  * RPC_STATUS_ERROR   : The connection failed to establish.
- *                      data is the erro string.
+ *                      data is the error string.
  * RPC_STATUS_CANCEL  : The connection attempt was aborted before it could complete.
  *                    : data is NULL.
  */

--- a/ccan/nfs/libnfs.c
+++ b/ccan/nfs/libnfs.c
@@ -440,7 +440,7 @@ static void nfs_mount_1_cb(struct rpc_context *rpc, int status, void *command_da
 }
 
 /*
- * Async call for mounting an nfs share and geting the root filehandle
+ * Async call for mounting an nfs share and getting the root filehandle
  */
 int nfs_mount_async(struct nfs_context *nfs, const char *server, const char *export, nfs_cb cb, void *private_data)
 {
@@ -554,7 +554,7 @@ static int nfs_lookuppath_async(struct nfs_context *nfs, const char *path, nfs_c
 	struct nfs_cb_data *data;
 
 	if (path[0] != '/') {
-		rpc_set_error(nfs->rpc, "Pathname is not absulute %s", path);
+		rpc_set_error(nfs->rpc, "Pathname is not absolute %s", path);
 		return -1;
 	}
 

--- a/ccan/nfs/pdu.c
+++ b/ccan/nfs/pdu.c
@@ -120,7 +120,7 @@ int rpc_get_pdu_size(char *buf)
 	size = ntohl(*(uint32_t *)buf);
 
 	if ((size & 0x80000000) == 0) {
-		printf("cant handle oncrpc fragments\n");
+		printf("can't handle oncrpc fragments\n");
 		return -1;
 	}
 

--- a/ccan/opt/opt.h
+++ b/ccan/opt/opt.h
@@ -361,7 +361,7 @@ void opt_log_stderr(const char *fmt, ...);
  * when handed to opt_parse, opt_parse will never return false.
  *
  * Example:
- *	// This never returns false; just exits if there's an erorr.
+ *	// This never returns false; just exits if there's an error.
  *	opt_parse(&argc, argv, opt_log_stderr_exit);
  */
 void opt_log_stderr_exit(const char *fmt, ...);

--- a/ccan/order/test/api.c
+++ b/ccan/order/test/api.c
@@ -20,7 +20,7 @@
 		t arr1[num], arr2[num];					\
 		int i;							\
 									\
-		/* Intialize arr1 in reverse order */			\
+		/* Initialize arr1 in reverse order */			\
 		for (i = 0; i < num; i++)				\
 			arr1[i] = arr0[num-i-1];			\
 									\
@@ -41,7 +41,7 @@
 		t arr1[num], arr2[num];					\
 		int i;							\
 									\
-		/* Intialize arr1 in reverse order */			\
+		/* Initialize arr1 in reverse order */			\
 		for (i = 0; i < num; i++)				\
 			arr1[i] = arr0[num-i-1];			\
 									\
@@ -78,7 +78,7 @@
 			arr0[i].val = arrbase[i];			\
 		}							\
 									\
-		/* Intialize arr1 in reverse order */			\
+		/* Initialize arr1 in reverse order */			\
 		for (i = 0; i < num; i++)				\
 			arr1[i] = arr0[num-i-1];			\
 									\

--- a/ccan/pipecmd/pipecmd.h
+++ b/ccan/pipecmd/pipecmd.h
@@ -36,7 +36,7 @@ pid_t pipecmd(int *infd, int *outfd, int *errfd, const char *cmd, ...);
 pid_t pipecmdv(int *infd, int *outfd, int *errfd, const char *cmd, va_list ap);
 
 /**
- * pipecmdarr - run a command, optionally connect pipes (char arry version)
+ * pipecmdarr - run a command, optionally connect pipes (char array version)
  * @infd: input fd to write to child (if non-NULL)
  * @outfd: output fd to read from child (if non-NULL)
  * @errfd: error-output fd to read from child (if non-NULL)

--- a/ccan/ptr_valid/ptr_valid.c
+++ b/ccan/ptr_valid/ptr_valid.c
@@ -264,7 +264,7 @@ static bool check_with_child(struct ptr_valid_batch *batch,
 }
 
 /* msync seems most well-defined test, but page could be mapped with
- * no permissions, and can't distiguish readonly from writable. */
+ * no permissions, and can't distinguish readonly from writable. */
 bool ptr_valid_batch(struct ptr_valid_batch *batch,
 		     const void *p, size_t alignment, size_t size, bool write)
 {

--- a/ccan/rbtree/rbtree.h
+++ b/ccan/rbtree/rbtree.h
@@ -61,7 +61,7 @@ void *trbt_insert32(trbt_tree_t *tree, uint32_t key, void *data);
      tree.
    If a node already exists for this key then:
      callback is called with data==existing data and param=param
-     the returned calue is talloc_stolen and inserted in the tree
+     the returned value is talloc_stolen and inserted in the tree
 */
 void trbt_insert32_callback(trbt_tree_t *tree, uint32_t key, void *(*callback)(void *param, void *data), void *param);
 

--- a/ccan/tal/str/str.h
+++ b/ccan/tal/str/str.h
@@ -201,7 +201,7 @@ char *tal_strjoin_(const void *ctx,
  * Example:
  *	// Given "My name is Rusty" outputs "Hello Rusty!\n"
  *	// Given "my first name is Rusty Russell" outputs "Hello Rusty Russell!\n"
- *	// Given "My name isnt Rusty Russell" outputs "Hello there!\n"
+ *	// Given "My name isn't Rusty Russell" outputs "Hello there!\n"
  *	int main(int argc, char *argv[])
  *	{
  *		char *person, *input;

--- a/ccan/tal/tal.h
+++ b/ccan/tal/tal.h
@@ -386,7 +386,7 @@ tal_t *tal_parent(const tal_t *ctx);
  * @type: the type (should match type of @p!)
  * @p: the tal array to copy (or resized & reparented if take())
  *
- * The comon case of duplicating an entire tal array.
+ * The common case of duplicating an entire tal array.
  */
 #define tal_dup_talarr(ctx, type, p)					\
 	((type *)tal_dup_talarr_((ctx), tal_typechk_(p, type *),	\

--- a/ccan/talloc/_info
+++ b/ccan/talloc/_info
@@ -6,7 +6,7 @@
  * talloc - tree allocator routines
  *
  * Talloc is a hierarchical memory pool system with destructors: you keep your
- * objects in heirarchies reflecting their lifetime.  Every pointer returned
+ * objects in hierarchies reflecting their lifetime.  Every pointer returned
  * from talloc() is itself a valid talloc context, from which other talloc()s
  * can be attached.  This means you can do this:
  *

--- a/ccan/wwviaudio/wwviaudio.h
+++ b/ccan/wwviaudio/wwviaudio.h
@@ -101,7 +101,7 @@ GLOBAL void wwviaudio_silence_music(void);
 /* Unsilence the music channel */
 GLOBAL void wwviaudio_resume_music(void);
 
-/* Silence or unsilence the music channe. */
+/* Silence or unsilence the music channel. */
 GLOBAL void wwviaudio_toggle_music(void);
 
 /* Stop playing the playing buffer from the music channel */

--- a/junkcode/iasoule32@gmail.com-polynomial/polynomial_adt.h
+++ b/junkcode/iasoule32@gmail.com-polynomial/polynomial_adt.h
@@ -59,7 +59,7 @@ PolyAdt *create_adt(int hp);
 
 /**
 * create_node - creates a Node (exponent, constant and next pointer) on the heap
-* @constant: the contant in the term
+* @constant: the constant in the term
 * @exp:      the exponent on the term
 * @next:     the next pointer to another term in the polynomial
 *

--- a/junkcode/iasoule32@gmail.com-polynomial/test/run.c
+++ b/junkcode/iasoule32@gmail.com-polynomial/test/run.c
@@ -81,7 +81,7 @@ int main(void)
     PolyAdt *deriv, *integral;
     
     deriv = derivative(p);
-    printf("The derivitive of p = ");
+    printf("The derivative of p = ");
     display_poly(deriv);
     integral = integrate(q);
     

--- a/junkcode/rusty@rustcorp.com.au-ntdb/doc/design.lyx
+++ b/junkcode/rusty@rustcorp.com.au-ntdb/doc/design.lyx
@@ -1453,7 +1453,7 @@ context
 \end_layout
 
 \begin_layout Standard
-This would form a talloc heirarchy as expected, but the caller would still
+This would form a talloc hierarchy as expected, but the caller would still
  have to attach a destructor to the tdb context returned from tdb_open to
  close it.
  All TDB_DATA fields would be children of the tdb_context, and the caller
@@ -1695,7 +1695,7 @@ Status
 \begin_layout Standard
 Ignore.
  Scaling the hash automatically proved inefficient at small hash sizes;
- we default to a 8192-element hash (changable via NTDB_ATTRIBUTE_HASHSIZE),
+ we default to a 8192-element hash (changeable via NTDB_ATTRIBUTE_HASHSIZE),
  and when buckets clash we expand to an array of hash entries.
  This scales slightly better than the tdb chain (due to the 8 top bits containin
 g extra hash).
@@ -1795,7 +1795,7 @@ Examine the following block to see if it is free; if so, enlarge the current
 \end_layout
 
 \begin_layout Enumerate
-Examine the preceeding block to see if it is free: for this reason, each
+Examine the preceding block to see if it is free: for this reason, each
  block has a 32-bit tailer which indicates its length.
  If it is free, expand it to cover our new block and return.
 \end_layout

--- a/junkcode/rusty@rustcorp.com.au-ntdb/doc/design.txt
+++ b/junkcode/rusty@rustcorp.com.au-ntdb/doc/design.txt
@@ -600,7 +600,7 @@ tdb_open() to provide an alternate allocation mechanism,
 specifically for talloc but usable by any other allocator (which
 would ignore the“context” argument).
 
-This would form a talloc heirarchy as expected, but the caller
+This would form a talloc hierarchy as expected, but the caller
 would still have to attach a destructor to the tdb context
 returned from tdb_open to close it. All TDB_DATA fields would be
 children of the tdb_context, and the caller would still have to
@@ -735,7 +735,7 @@ invalid.
 3.4.2 Status
 
 Ignore. Scaling the hash automatically proved inefficient at
-small hash sizes; we default to a 8192-element hash (changable
+small hash sizes; we default to a 8192-element hash (changeable
 via NTDB_ATTRIBUTE_HASHSIZE), and when buckets clash we expand to
 an array of hash entries. This scales slightly better than the
 tdb chain (due to the 8 top bits containing extra hash).
@@ -786,7 +786,7 @@ Deleting a record occurs as follows:
   from the free list. This was disabled, as removal from the free
   list was O(entries-in-free-list).
 
-6. Examine the preceeding block to see if it is free: for this
+6. Examine the preceding block to see if it is free: for this
   reason, each block has a 32-bit tailer which indicates its
   length. If it is free, expand it to cover our new block and
   return.

--- a/junkcode/rusty@rustcorp.com.au-ntdb/test/api-open-multiple-times.c
+++ b/junkcode/rusty@rustcorp.com.au-ntdb/test/api-open-multiple-times.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 		ok1(ntdb_chainlock(ntdb, key) == NTDB_ERR_LOCK);
 		ok1(tap_log_messages == 4);
 
-		/* Transaciton should work as normal. */
+		/* Transaction should work as normal. */
 		ok1(ntdb_store(ntdb2, key, data, NTDB_REPLACE) == NTDB_SUCCESS);
 
 		/* Now... try closing with locks held. */

--- a/junkcode/rusty@rustcorp.com.au-ntdb/test/lock-tracking.c
+++ b/junkcode/rusty@rustcorp.com.au-ntdb/test/lock-tracking.c
@@ -1,4 +1,4 @@
-/* We save the locks so we can reaquire them. */
+/* We save the locks so we can reacquire them. */
 #include "../private.h" /* For NTDB_HASH_LOCK_START, etc. */
 #include <unistd.h>
 #include <fcntl.h>

--- a/tools/gen_deps.sh
+++ b/tools/gen_deps.sh
@@ -10,7 +10,7 @@ module=`echo $path | sed 's/^ccan\///g'`
 test_srcs=`ls $path/test/*.[ch] 2>/dev/null | tr '\n' ' '`
 
 # ... and the object files of our module (rather than the sources, so
-#     that we pick up the resursive dependencies for the objects)
+#     that we pick up the recursive dependencies for the objects)
 module_objs=`ls $path/*.c 2>/dev/null | sed 's/.c$/.o/g' | tr '\n' ' '`
 
 # ... and on the modules this test uses having passed their tests


### PR DESCRIPTION
The rationale is that this is reusable code. When reused in other software packages, it will raise alerts when spellchecking those other software packages. Of course, it is quite possible to silence alerts or fix them in vendored CCAN code, but I thought that fixing the typos upstream would be more efficient for all.