### PR TITLE
opt: increase show length from 80 to 100

### DIFF
--- a/ccan/opt/opt.h
+++ b/ccan/opt/opt.h
@@ -430,7 +430,7 @@ void opt_usage_exit_fail(const char *msg, ...) NORETURN;
 extern const char opt_hidden[];
 
 /* Maximum length of arg to show in opt_usage */
-#define OPT_SHOW_LEN 80
+#define OPT_SHOW_LEN 100
 
 /* Standard helpers.  You can write your own: */
 /* Sets the @b to true. */


### PR DESCRIPTION
I was seaching on why there is the opt show
length and why it is 80 and I found the following
information in https://unix.stackexchange.com/a/367012/369490

An extraction is:

SUSv3 doesn’t specify the size of the sun_path field. Early BSD implementations used 108 and 104 bytes,
and one contemporary implementation (HP-UX 11) uses 92 bytes. Portable applications should code to this lower value, and use snprintf() or strncpy() to avoid buffer overruns when writing into this field.

OpenBSD: 104 characters
FreeBSD: 104 characters
Mac OS X 10.9: 104 characters

I do not know if 100 is a good value for it, but
looks like that all modern OS support at least
100 as length upperbound.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>