### PR TITLE
endian.h: Guard against __{BIG,LITTLE}_ENDIAN being defined

### DIFF
--- a/ccan/endian/endian.h
+++ b/ccan/endian/endian.h
@@ -104,8 +104,10 @@ static inline uint64_t bswap_64(uint64_t val)
 #endif
 
 /* Needed for Glibc like endiness check */
+#ifndef __LITTLE_ENDIAN
 #define	__LITTLE_ENDIAN	1234
 #define	__BIG_ENDIAN	4321
+#endif
 
 /* Sanity check the defines.  We don't handle weird endianness. */
 #if !HAVE_LITTLE_ENDIAN && !HAVE_BIG_ENDIAN


### PR DESCRIPTION
When compiled on FreeBSD, we get both __LITTLE_ENDIAN and __BIG_ENDIAN defined. glibc defines these as well, but it defines them to 1234 and
4321. However, FreeBSD defines them to __ORDER_LITTLE_ENDIAN__ and __ORDER_BIG_ENDIAN__ to take advantage of the recent gcc and clang predefines. Check to see if __LITTLE_ENDIAN is defined before we redefine it. This is less than perfect, I'll grant, but anything starting with __ is in the implementation namespace so some care needs to be taken.