### PR TITLE
ccan/ciniparser: fix truncation warning

### DIFF
--- a/ccan/ciniparser/ciniparser.c
+++ b/ccan/ciniparser/ciniparser.c
@@ -379,7 +379,7 @@ dictionary *ciniparser_load(const char *ininame)
 	char line[ASCIILINESZ+1];
 	char section[ASCIILINESZ+1];
 	char key[ASCIILINESZ+1];
-	char tmp[ASCIILINESZ+1];
+	char tmp[2*ASCIILINESZ+2];
 	char val[ASCIILINESZ+1];
 	int  last = 0, len, lineno = 0, errs = 0;
 	dictionary *dict;
@@ -439,7 +439,7 @@ dictionary *ciniparser_load(const char *ininame)
 			break;
 
 		case LINE_VALUE:
-			snprintf(tmp, ASCIILINESZ + 1, "%s:%s", section, key);
+			snprintf(tmp, sizeof(tmp), "%s:%s", section, key);
 			errs = dictionary_set(dict, tmp, val);
 			break;
 


### PR DESCRIPTION
Increase size of tmp buffer to avoid warning:

```
ninja: Entering directory `build'
[1/2] Compiling C object trappist.p/ccan_ccan_ciniparser_ciniparser.c.o
../ccan/ccan/ciniparser/ciniparser.c: In function ‘ciniparser_load’:
../ccan/ccan/ciniparser/ciniparser.c:443:56: warning: ‘%s’ directive output may be truncated writing up to 1024 bytes into a region of size between 0 and 1024 [-Wformat-truncation=]
  443 |                         snprintf(tmp, sizeof(tmp), "%s:%s", section, key);
      |                                                        ^~            ~~~
../ccan/ccan/ciniparser/ciniparser.c:443:25: note: ‘snprintf’ output between 2 and 2050 bytes into a destination of size 1025
  443 |                         snprintf(tmp, sizeof(tmp), "%s:%s", section, key);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2/2] Linking target trappist
```