### PR TITLE
ccan/opt: fix comparison with different signedness

### DIFF
--- a/ccan/opt/helpers.c
+++ b/ccan/opt/helpers.c
@@ -461,7 +461,7 @@ static void show_llong_with_suffix(char *buf, size_t len, long long ll,
 				   const long long base)
 {
 	const char *suffixes = "kMGTPE";
-	int i;
+	size_t i;
 	if (ll == 0){
 		/*zero is special because everything divides it (you'd get "0E")*/
 		snprintf(buf, len, "0");
@@ -484,7 +484,7 @@ static void show_ullong_with_suffix(char *buf, size_t len,
 				    const unsigned base)
 {
 	const char *suffixes = "kMGTPE";
-	int i;
+	size_t i;
 	if (ull == 0){
 		/*zero is special because everything divides it (you'd get "0E")*/
 		snprintf(buf, len, "0");

--- a/ccan/opt/opt.c
+++ b/ccan/opt/opt.c
@@ -179,7 +179,8 @@ void _opt_register(const char *names, enum opt_type type,
 
 bool opt_unregister(const char *names)
 {
-	int found = -1, i;
+	int found = -1;
+	unsigned int i;
 
 	for (i = 0; i < opt_count; i++) {
 		if (opt_table[i].type & OPT_SUBTABLE)


### PR DESCRIPTION
...to avoid compiler warning.