### PR TITLE
NULL Pointer Dereference vulnerability in `int iscsi_process_text_reply()`

### DIFF
--- a/ccan/btree/btree.c
+++ b/ccan/btree/btree.c
@@ -505,6 +505,10 @@ static void node_insert(const void *x, struct btree_node *xr,
 			p->branch[i+1]->k = i+1;
 		}
 		p->branch[k] = xr;
+		if(!xr)
+		{
+			return;
+		}
 		xr->parent = p;
 		xr->k = k;
 	}

--- a/ccan/iscsi/discovery.c
+++ b/ccan/iscsi/discovery.c
@@ -147,6 +147,13 @@ int iscsi_process_text_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 			target->next = targets;
 			targets = target;
 		} else if (!strncmp((char *)hdr, "TargetAddress=", 14)) {
+			if(!targets)
+			{
+				printf("Failed to assign the value of targets.\n", hdr);
+				pdu->callback(iscsi, ISCSI_STATUS_ERROR, NULL, pdu->private_data);
+				iscsi_free_discovery_addresses(targets);
+				return -1;
+			}
 			targets->target_address = strdup((char *)hdr+14);
 			if (targets->target_address == NULL) {
 				printf("Failed to allocate data for new discovered target address\n");


### PR DESCRIPTION
The NULL Dereference vulnerability happens in `int iscsi_process_text_reply()`, `ccan/iscsi/discovery.c`
How the NULL Pointer Dereference happens:
1. `*targets` is set to NULL at `struct iscsi_discovery_address *targets = NULL;`
2. When the following conditions are met: `size > 0`, `len != 0`, and `len <= size`.
3. Dereference of NULL variable `targets->target_address` in `targets->target_address = strdup((char *)hdr+14);`
```
int iscsi_process_text_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pdu, const unsigned char *hdr, int size)
{
=>  struct iscsi_discovery_address *targets = NULL;
    ...
  while (size > 0) {
        int len;
        len = strlen((char *)hdr);
      if (len == 0) {
            break;
        }
        if (len > size) {
            ......
        }
        if (!strncmp((char *)hdr, "TargetName=", 11)) {
            ......
        } else if  (!strncmp((char *)hdr, "TargetAddress=", 14)) {
=>         targets->target_address = strdup((char *)hdr+14);
            ......
        }
    ......
}

```

The NULL Dereference vulnerability happens in `static void node_insert()`, `ccan/btree/btree.c`
How the NULL Pointer Dereference happens:
1. `*xr` is set to NULL at `btree_insert_at()`，`struct btree_node *xr = NULL;`
2. Then, `*xr` is passed as a parameter to the `node_insert()` function.
3. Dereference of NULL variable `xr->parent` in `xr->parent = p;`
```
void btree_insert_at(btree_iterator iter, const void *item)
{
    const void *x = item;
=>  struct btree_node *xr = NULL;
    ...
    if (iter->node->count < MAX) {
=>      node_insert(x, xr, iter->node, iter->k);
        ...
    }
    ......
}      

static void node_insert(const void *x, struct btree_node *xr,struct btree_node *p, unsigned int k)
{
    unsigned int i;
    for (i = p->count; i-- > k;)
        p->item[i+1] = p->item[i];
    p->item[k] = x;
    if (p->depth) {
        k++;
        for (i = p->count+1; i-- > k;) {
            p->branch[i+1] = p->branch[i];
            p->branch[i+1]->k = i+1;
            }
        p->branch[k] = xr;
=>      xr->parent = p;
        ......
        }
    ......
}    
```
