### PR TITLE
Remove ccodearchive.net references

### DIFF
--- a/Makefile-web
+++ b/Makefile-web
@@ -2,7 +2,7 @@ default: upload
 
 include Makefile
 # This can be overridden on cmdline to generate pages elsewhere.
-WEBDIR=/srv/www/ccodearchive.net
+WEBDIR=
 PHP=php
 
 MODS := $(ALL_MODULES:ccan/%=%)

--- a/README
+++ b/README
@@ -1,4 +1,8 @@
-The C Code Archive Network: http://ccodearchive.net
+The C Code Archive Network
+
+WARNING: The previous website (ccodearchive dot net) has, alas, been
+taken over by domain squatters who have an out of date copy of the
+site with sneaky ad links added.
 
 You can find a set of helper utilities under tools/ and the modules
 under ccan/.  The recommended way to add ccan modules to your project

--- a/doc/ccanlint.1
+++ b/doc/ccanlint.1
@@ -437,7 +437,7 @@ Collect the tests again, but not more features\&.
 Rusty Russell wrote \fBccanlint\fR\&. Helping others, but most break Rusty\&.
 .SH "RESOURCES"
 .sp
-Main web site: http://ccodearchive\&.net/
+Main web site: https://github\&.com/rustyrussell/ccan
 .sp
 Wiki: https://github\&.com/rustyrussell/ccan/wiki/
 .SH "COPYING"

--- a/doc/ccanlint.1.txt
+++ b/doc/ccanlint.1.txt
@@ -261,7 +261,7 @@ Rusty Russell wrote *ccanlint*. Helping others, but most break Rusty.
 
 RESOURCES
 ---------
-Main web site: http://ccodearchive.net/
+Main web site: http://github.com/rustyrussell/ccan
 
 Wiki: https://github.com/rustyrussell/ccan/wiki/
 

--- a/doc/configurator.1
+++ b/doc/configurator.1
@@ -208,7 +208,7 @@ It will exit with non\-zero status if it has a problem\&. \fB1\fR means bad comm
 Rusty Russell wrote \fBconfigurator\fR\&.
 .SH "RESOURCES"
 .sp
-Main web site: http://ccodearchive\&.net/
+Main web site: https://github\&.com/rustyrussell/ccan
 .sp
 Wiki: https://github\&.com/rustyrussell/ccan/wiki/
 .SH "COPYING"

--- a/doc/configurator.1.txt
+++ b/doc/configurator.1.txt
@@ -143,7 +143,8 @@ Rusty Russell wrote *configurator*.
 
 RESOURCES
 ---------
-Main web site: http://ccodearchive.net/
+Main web site: http://github.com/rustyrussell/ccan
+
 
 Wiki: https://github.com/rustyrussell/ccan/wiki/
 

--- a/web/menulist.html
+++ b/web/menulist.html
@@ -12,7 +12,6 @@ $url_prefix = getenv("URLPREFIX");
     <div class="search">
       <form method="get" action="http://www.google.com/search">
         <input type="text"   name="q" size="25" maxlength="255" value="" />
-        <input type="hidden" name="sitesearch" value="ccodearchive.net"/>
         <input type="submit" value="Search CCAN (Google)" />
       </form>
     </div>

--- a/web/static-configuration
+++ b/web/static-configuration
@@ -3,7 +3,7 @@
 $tempfolder = "/home/ccan/upload-temp/";
 
 //location of upload script (for posting uploads)
-$uploadscript = "http://ccodearchive.net/uploader.php";
+//$uploadscript = XXX;
 
 //ccan admin
 $ccanadmin = "rusty@rustcorp.com.au";

--- a/web/staticupload.php
+++ b/web/staticupload.php
@@ -13,10 +13,9 @@ Got C code sitting around which might help someone?  Put it to work
 by uploading here; .tar.gz, .zip or even single C files.
 </p>
 
-<p>If it has a valid _info file and a testsuite (see <a href="http://ccodearchive.net/Wiki/ModuleGuide">the module creation guide</a>), it'll go into the
+<p>If it has a valid _info file and a testsuite, it'll go into the
 main repository.  Otherwise, it'll go into our "junkcode" area where
-people can browse and download it.
-</p>
+people can browse and download it.  </p>
 
 <table align="center">
 <tr>


### PR DESCRIPTION
Our former website ccodearchive.net has been taken over by domain squatters, who've put up a near-duplicate of the former site with sneeaky advertising links inserted.  No idea if they've also subverted the actual code, but it's possible.

There is, alas, not much we can do about that.  We can, at least, stop linking to it in the repository though.  So, remove all references to the now untrustworthy website.