### PR TITLE
compiler: add `RETURNS_UNALIASED` macro for `malloc`-like functions

### DIFF
--- a/ccan/compiler/_info
+++ b/ccan/compiler/_info
@@ -12,6 +12,8 @@
  *	For functions which take printf-style parameters.
  * - CONST_FUNCTION
  *	For functions which return the same value for same parameters.
+ * - RETURNS_UNALIASED
+ *	For malloc-like functions that never return an aliased pointer.
  * - NEEDED
  *	For functions and variables which must be emitted even if unused.
  * - UNNEEDED

--- a/ccan/compiler/compiler.h
+++ b/ccan/compiler/compiler.h
@@ -91,6 +91,25 @@
 #endif
 #endif
 
+#ifndef RETURNS_UNALIASED
+#if HAVE_ATTRIBUTE_MALLOC
+/**
+ * RETURNS_UNALIASED - a function never returns a pointer that is aliased
+ *
+ * This affords the optimizer the opportunity to assume that writes through the
+ * returned pointer cannot modify memory accessible via any other pointer and
+ * vice versa.
+ *
+ * Example:
+ *	// Returns a pointer to newly allocated memory.
+ *	static RETURNS_UNALIASED void *my_alloc(size_t);
+ */
+#define RETURNS_UNALIASED __attribute__((__malloc__))
+#else
+#define RETURNS_UNALIASED
+#endif
+#endif
+
 #if HAVE_ATTRIBUTE_UNUSED
 #ifndef UNNEEDED
 /**

--- a/ccan/tal/tal.h
+++ b/ccan/tal/tal.h
@@ -531,11 +531,12 @@ bool tal_set_name_(tal_t *ctx, const char *name, bool literal);
 #endif
 
 void *tal_alloc_(const tal_t *ctx, size_t bytes, bool clear, const char *label)
-	TAL_RETURN_PTR;
+	TAL_RETURN_PTR RETURNS_UNALIASED;
 void *tal_alloc_arr_(const tal_t *ctx, size_t bytes, size_t count, bool clear,
 		     const char *label)
-	TAL_RETURN_PTR;
+	TAL_RETURN_PTR RETURNS_UNALIASED;
 
+/* Cannot be RETURNS_UNALIASED because may return argument. */
 void *tal_dup_(const tal_t *ctx, const void *p TAKES, size_t size,
 	       size_t n, size_t extra, bool nullok, const char *label);
 void *tal_dup_talarr_(const tal_t *ctx, const tal_t *src TAKES,

--- a/tools/configurator/configurator.c
+++ b/tools/configurator/configurator.c
@@ -151,6 +151,10 @@ static const struct test base_tests[] = {
 	{ "HAVE_ATTRIBUTE_PURE", "__attribute__((pure)) support",
 	  "DEFINES_FUNC", NULL, NULL,
 	  "static int __attribute__((pure)) func(int x) { return x; }" },
+	{ "HAVE_ATTRIBUTE_MALLOC", "__attribute__((malloc)) support",
+	  "DEFINES_FUNC", NULL, NULL,
+	  "#include <stdlib.h>\n"
+	  "static void * __attribute__((__malloc__)) func(size_t n) { return malloc(n); }" },
 	{ "HAVE_ATTRIBUTE_MAY_ALIAS", "__attribute__((may_alias)) support",
 	  "OUTSIDE_MAIN", NULL, NULL,
 	  "typedef short __attribute__((__may_alias__)) short_a;" },


### PR DESCRIPTION
This affords the optimizer the opportunity to assume that writes through the returned pointer cannot modify memory accessible via any other pointer and vice versa.

Then mark `tal_alloc_()` and `tal_alloc_arr_()` as `RETURNS_UNALIASED`.