### PR TITLE
json_escape: add `json_escape_unescape_len(…)`

### DIFF
--- a/ccan/json_escape/json_escape.h
+++ b/ccan/json_escape/json_escape.h
@@ -41,4 +41,8 @@ struct json_escape *json_escape_string_(const tal_t *ctx,
 /* Be very careful here!  Can fail!  Doesn't handle \u: use UTF-8 please. */
 const char *json_escape_unescape(const tal_t *ctx,
 				 const struct json_escape *esc);
+
+/* Be very careful here!  Can fail!  Doesn't handle \u: use UTF-8 please. */
+const char *json_escape_unescape_len(const tal_t *ctx,
+				     const char *esc TAKES, size_t len);
 #endif /* CCAN_JSON_ESCAPE_H */


### PR DESCRIPTION
Lacking a variant of `json_escape_unescape(…)` that takes a sized span, the common case of unescaping a JSON string that is embedded inside a larger buffer is forced to make a copy of the escaped string so as to terminate it with a NUL character. This extra copy can be avoided if we can pass an explicit length to the unescaping function.

Also, a drive-by fix: shrink the returned unescaped string to fit its contents, which can save the caller a subsequent call to `strlen()`.