### PR TITLE
Update poll for Mac POLLHUP behavior

### DIFF
--- a/ccan/io/poll.c
+++ b/ccan/io/poll.c
@@ -433,6 +433,7 @@ void *io_loop(struct timers *timers, struct timer **expired)
 
 		fairness_counter++;
 		for (size_t rotation = 0; rotation < num_fds && !io_loop_return; rotation++) {
+			socklen_t errno_len = sizeof(errno);
 			struct io_conn *c;
 			int events;
 
@@ -469,8 +470,18 @@ void *io_loop(struct timers *timers, struct timer **expired)
 				r--;
 				io_ready(c, events);
 			} else if (events & (POLLHUP|POLLNVAL|POLLERR)) {
+				/* On `connect` failure, Linux typically
+				 * returns POLLIN|POLLERR. MacOS returns either
+				 * POLLHUP|POLLERR or POLLOUT|POLLHUP depending
+				 * on version, setting the socket error to
+				 * ECONNREFUSED. */
 				r--;
-				errno = EBADF;
+				/* Get fd's specific error to find Mac's
+				 * ECONNREFUSED, among others */
+				if(getsockopt(fds[i]->fd, SOL_SOCKET, SO_ERROR,
+					      &errno, &errno_len) == -1) {
+					errno = EBADF;
+				}
 				io_close(c);
 			}
 		}


### PR DESCRIPTION
When `connect`ing on Linux, a rejection typically returns “POLLIN|POLLERR” from `poll` on Linux.

Mac differs in this situation returning one of two values from poll (depending on Mac version): “POLLHUP|POLLERR”
“POLLOUT|POLLHUP”

Mac also sets the socket’s error to ECONNREFUSED in this case.

We can support this behavior by getting the SO_ERROR off the socket in the POLLHUP case, which has the added benefit of more explicity error messages generally.

Signed-off-by: Dusty Daemon @dusty_daemon