### PR TITLE
Fix json_out_addstrn to respect length when escaping

### DIFF
--- a/ccan/json_out/json_out.c
+++ b/ccan/json_out/json_out.c
@@ -306,7 +306,7 @@ bool json_out_addstrn(struct json_out *jout,
 	struct json_escape *e;
 
 	if (json_escape_needed(str, len)) {
-		e = json_escape(NULL, str);
+		e = json_escape_len(NULL, str, len);
 		str = e->s;
 		len = strlen(str);
 	} else


### PR DESCRIPTION
`json_out_addstrn`'s escape path calls json_escape(NULL, str), which uses `strlen` instead of the length passed in. This was introduced in https://github.com/ElementsProject/lightning/commit/400f97d3bbd5a6088407a88b54eb9dd128ddd19b, which routed `json_add_stringn` through `json_out_addstrn` for efficiency but the old path used `json_escape_len`, so the explicit length was respected.

This breaks callers that pass non-NUL-terminated strings. In CLN, log messages live in a ring buffer and are not NUL-terminated at loglen, so when a log line contains an escapable character, strlen reads past loglen into adjacent ring-buffer memory and emits invalid UTF-8.

Fix the escape branch to use json_escape_len instead.