### PR TITLE
Build fixes for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tools/_infotojson/infotojson
 tools/ccanlint/test/run-file_analysis
 tools/configurator/configurator
 scores/
+*.dSYM

--- a/ccan/coroutine/coroutine.c
+++ b/ccan/coroutine/coroutine.c
@@ -60,7 +60,14 @@ struct coroutine_stack *coroutine_stack_init(void *buf, size_t bufsize,
 	size_t size = bufsize - sizeof(*stack) - metasize;
 
 #ifdef MINSIGSTKSZ
+# if defined(__APPLE__)
+	/* MINSIGSTKSZ is a runtime value on macOS 14+, not a compile-time
+	 * constant, so it can't be used in BUILD_ASSERT; check at runtime. */
+	if (COROUTINE_MIN_STKSZ < (size_t)MINSIGSTKSZ)
+		return NULL;
+# else
 	BUILD_ASSERT(COROUTINE_MIN_STKSZ >= MINSIGSTKSZ);
+# endif
 #endif
 
 	if (bufsize < (COROUTINE_MIN_STKSZ + sizeof(*stack) + metasize))

--- a/tools/create-ccan-tree
+++ b/tools/create-ccan-tree
@@ -17,7 +17,23 @@ EOF
 # parse options, setting the following flags
 build_type=
 
-opts=$(getopt -o ab: --long copy-all,build-type: -n $progname -- "$@")
+# macOS ships BSD getopt which lacks --long; prefer GNU getopt if available
+if [ -x /opt/homebrew/opt/gnu-getopt/bin/getopt ]; then
+	GETOPT=/opt/homebrew/opt/gnu-getopt/bin/getopt
+elif [ -x /usr/local/opt/gnu-getopt/bin/getopt ]; then
+	GETOPT=/usr/local/opt/gnu-getopt/bin/getopt
+else
+	# GNU getopt returns 4 from --test; BSD getopt does not
+	getopt --test > /dev/null 2>&1
+	if [ $? -eq 4 ]; then
+		GETOPT=getopt
+	else
+		echo "$progname: GNU getopt required (on macOS: brew install gnu-getopt)" >&2
+		exit 1
+	fi
+fi
+
+opts=$("$GETOPT" -o ab: --long copy-all,build-type: -n $progname -- "$@")
 
 if [ $? != 0 ]
 then


### PR DESCRIPTION
Four independent fixes so ccan builds on macOS with Apple clang. Each is a separate commit.

- **build: probe for `-Wshadow=local`** — Apple clang rejects this flag, so `make` fails immediately. Add it only when the compiler accepts it (kept on GCC/newer clang).
- **coroutine: runtime `MINSIGSTKSZ` on macOS 14+** — on macOS 14+ `MINSIGSTKSZ` expands to a runtime value, not a compile-time constant, so it can't be used in `BUILD_ASSERT`. Use a runtime check on Apple platforms; keep the compile-time assertion elsewhere.
- **create-ccan-tree: use GNU getopt** — macOS ships BSD getopt, which lacks `--long`. Prefer a Homebrew `gnu-getopt` if present, else detect GNU getopt via its `--test` exit code and fail with a helpful message.
- **gitignore: ignore `*.dSYM`** — macOS/clang emits `.dSYM` debug-symbol bundles next to built binaries.

No functional change on Linux.